### PR TITLE
add custom yaml field for github repo name

### DIFF
--- a/releases/1.4/kubeflow-bundle.yaml
+++ b/releases/1.4/kubeflow-bundle.yaml
@@ -5,46 +5,56 @@ applications:
     charm: admission-webhook
     channel: 1.4/stable
     scale: 1
+    _github_repo_name: admission-webhook-operator
   argo-controller:
     charm: argo-controller
     channel: 3.1/stable
     scale: 1
+    _github_repo_name: argo-operators
   argo-server:
     charm: argo-server
     channel: 3.1/stable
     scale: 1
+    _github_repo_name: argo-operators
   dex-auth:
     charm: dex-auth
     channel: 2.28/stable
     scale: 1
     trust: true
+    _github_repo_name: dex-auth-operator
   envoy:
     charm: envoy
     channel: 1.12/stable
     scale: 1
+    _github_repo_name: envoy-operator
   istio-ingressgateway:
     charm: istio-gateway
     channel: 1.5/stable
     scale: 1
     trust: true
+    _github_repo_name: istio-operators
   istio-pilot:
     charm: istio-pilot
     channel: 1.5/stable
     scale: 1
+    _github_repo_name: istio-operators
     options:
       default-gateway: kubeflow-gateway
   jupyter-controller:
     charm: jupyter-controller
     channel: 1.4/stable
     scale: 1
+    _github_repo_name: notebook-operators
   jupyter-ui:
     charm: jupyter-ui
     channel: 1.4/stable
     scale: 1
+    _github_repo_name: notebook-operators
   katib-controller:
     charm: katib-controller
     channel: 0.12/stable
     scale: 1
+    _github_repo_name: katib-operators
   katib-db:
     charm: charmed-osm-mariadb-k8s
     channel: latest/stable
@@ -55,14 +65,17 @@ applications:
     charm: katib-db-manager
     channel: 0.12/stable
     scale: 1
+    _github_repo_name: katib-operators
   katib-ui:
     charm: katib-ui
     channel: 0.12/stable
     scale: 1
+    _github_repo_name: katib-operators
   kfp-api:
     charm: kfp-api
     channel: 1.7/stable
     scale: 1
+    _github_repo_name: kfp-operators
   kfp-db:
     charm: charmed-osm-mariadb-k8s
     channel: latest/stable
@@ -73,77 +86,95 @@ applications:
     charm: kfp-persistence
     channel: 1.7/stable
     scale: 1
+    _github_repo_name: kfp-operators
   kfp-profile-controller:
     charm: kfp-profile-controller
     channel: 1.7/stable
     scale: 1
+    _github_repo_name: kfp-operators
   kfp-schedwf:
     charm: kfp-schedwf
     channel: 1.7/stable
     scale: 1
+    _github_repo_name: kfp-operators
   kfp-ui:
     charm: kfp-ui
     channel: 1.7/stable
     scale: 1
+    _github_repo_name: kfp-operators
   kfp-viewer:
     charm: kfp-viewer
     channel: 1.7/stable
     scale: 1
+    _github_repo_name: kfp-operators
   kfp-viz:
     charm: kfp-viz
     channel: 1.7/stable
     scale: 1
+    _github_repo_name: kfp-operators
   kubeflow-dashboard:
     charm: kubeflow-dashboard
     channel: 1.4/stable
     scale: 1
+    _github_repo_name: kubeflow-dashboard-operator
   kubeflow-profiles:
     charm: kubeflow-profiles
     channel: 1.4/stable
     scale: 1
+    _github_repo_name: kubeflow-profiles-operator
   kubeflow-roles:
     charm: kubeflow-roles
     channel: 1.4/stable
     scale: 1
     trust: true
+    _github_repo_name: kubeflow-roles-operator
   kubeflow-volumes:
     charm: kubeflow-volumes
     channel: 1.4/stable
     scale: 1
+    _github_repo_name: kubeflow-volumes-operator
   metacontroller-operator:
     charm: metacontroller-operator
     channel: 0.3/stable
     scale: 1
     trust: true
+    _github_repo_name: metacontroller-operator
   mlmd:
     charm: mlmd
     channel: 1.0/stable
     scale: 1
+    _github_repo_name: mlmd-operator
   minio:
     charm: minio
     channel: latest/stable
     scale: 1
+    _github_repo_name: minio-operator
   oidc-gatekeeper:
     charm: oidc-gatekeeper
     channel: ckf-1.4/stable
     scale: 1
+    _github_repo_name: oidc-gatekeeper-operator
   seldon-controller-manager:
     charm: seldon-core
     channel: 1.6/stable
     scale: 1
+    _github_repo_name: seldon-core-operator
   tensorboard-controller:
     charm: tensorboard-controller
     channel: 1.4/stable
     scale: 1
+    _github_repo_name: kubeflow-tensorboards-operator
   tensorboards-web-app:
     charm: tensorboards-web-app
     channel: 1.4/stable
     scale: 1
+    _github_repo_name: kubeflow-tensorboards-operator
   training-operator:
     charm: training-operator
     channel: 1.3/stable
     scale: 1
     trust: true
+    _github_repo_name: training-operator
 relations:
   - [argo-controller, minio]
   - [dex-auth:oidc-client, oidc-gatekeeper:oidc-client]

--- a/releases/1.4/mlflow.yaml
+++ b/releases/1.4/mlflow.yaml
@@ -5,6 +5,7 @@ applications:
     charm: mlflow-server
     channel: 1.13.1/stable
     scale: 1
+    _github_repo_name: mlflow-operator
   mlflow-db:
     charm: charmed-osm-mariadb-k8s
     channel: latest/stable

--- a/releases/1.4/spark.yaml
+++ b/releases/1.4/spark.yaml
@@ -5,3 +5,4 @@ applications:
     charm: spark-k8s
     channel: 3.1/stable
     scale: 1
+    _github_repo_name: spark-operator


### PR DESCRIPTION
Add custom yaml field `_github_repo_name` to indicate where the source code lives for each charm.
I didn't add `_github_repo_name` field for charmed-osm-mariadb-k8s because I don't know where it lives and we are not going to create a branch on their repo.

Github apis follow the following format:
`https://api.github.com/repos/{github_repo_owner}/{github_repo_name}/...`
It requires less data cleaning in the script to store repo owner and repo name separately.
So far, all of the repos are under `Canonical`. Therefore, only `_github_repo_name` field is added.
In the future, the script could be easily extended to support a `_github_repo_owner` field.