### PR TITLE
Pass bot token Environemnt variable through tox.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,8 @@ commands =
 
 [testenv:branch_track_creation]
 description = Run branch and track creation script
+passenv =
+  KUBEFLOW_BOT_TOKEN
 deps = 
   pyyaml
   requests


### PR DESCRIPTION
When executing the script the environment variable is currently not passed through to tox. This minor change will allow that for the branch automation script exclusively.