### PR TITLE
Add Track Request functionality

### DIFF
--- a/.github/workflows/branch_track_automation.yaml
+++ b/.github/workflows/branch_track_automation.yaml
@@ -26,3 +26,8 @@ jobs:
       - name: Run script (Workflow Dispatch)
         if: ${{ github.event_name == 'workflow_dispatch'}}
         run: tox -e branch_track_creation ${{ inputs.release_directory_path }}
+      - name: Upload track request file.
+        uses: actions/upload-artifact@v2
+        with:
+          name: track-request-artifact
+          path: track_request.txt

--- a/scripts/branch_track_creation.py
+++ b/scripts/branch_track_creation.py
@@ -169,6 +169,21 @@ def branch_creation_automation(release_path: str) -> None:
             f"track/{charms_info[charm]['version']}",
         )
 
+    create_track_request(charms_info)
+
+
+def create_track_request(charms_info: dict) -> None:
+    """Create a track request for each charm in the charms_info dictionary."""
+    # TODO check if the charm already has a track
+    logger.info(f"Creating track requests for charms")
+    track_request = "Charmhub Tracks Request\n"
+    track_request += "=======================\n"
+    for charm in charms_info:
+        track_request += f"{charm} -> {charms_info[charm]['version']}\n"
+    with open("track_request.txt", "w") as file:
+        file.write(track_request)
+        logger.info(f"Track request is written to {file.name}")
+
 
 if __name__ == "__main__":
     if not os.environ.get(GITHUB_TOKEN_NAME):


### PR DESCRIPTION
This commit adds an additional function which will generate a file with all the charmhub tracks that need to be available for a certain release. It will not yet check with charmhub if these tracks already exist.

It also will upload this file as an artifact when the github action is executed.