### PR TITLE
pin mlflow-server channel to minor version

### DIFF
--- a/releases/1.4/mlflow.yaml
+++ b/releases/1.4/mlflow.yaml
@@ -3,7 +3,7 @@ name: mlflow-overlay
 applications:
   mlflow-server:
     charm: mlflow-server
-    channel: 1.13.1/stable
+    channel: 1.13/stable
     scale: 1
     _github_repo_name: mlflow-operator
   mlflow-db:


### PR DESCRIPTION
Uses track in charmhub of `ch:1.13` instead of `ch:1.13.1`