### PR TITLE
Add kubeflow bundle for 1.6 using tracks and edge risk

### DIFF
--- a/releases/1.6/kubeflow-bundle.yaml
+++ b/releases/1.6/kubeflow-bundle.yaml
@@ -189,4 +189,3 @@ relations:
   - [kfp-profile-controller:object-storage, minio:object-storage]
   - [kfp-ui:object-storage, minio:object-storage]
   - [kubeflow-profiles, kubeflow-dashboard]
-  - [mlmd:grpc, envoy:grpc]

--- a/releases/1.6/kubeflow-bundle.yaml
+++ b/releases/1.6/kubeflow-bundle.yaml
@@ -1,0 +1,202 @@
+bundle: kubernetes
+name: kubeflow
+applications:
+  admission-webhook:
+    charm: admission-webhook
+    channel: 1.6/edge
+    scale: 1
+    _github_repo_name: admission-webhook-operator
+  argo-controller:
+    charm: argo-controller
+    channel: 3.3/edge
+    scale: 1
+    _github_repo_name: argo-operators
+  argo-server:
+    charm: argo-server
+    channel: 3.3/edge
+    scale: 1
+    _github_repo_name: argo-operators
+  dex-auth:
+    charm: dex-auth
+    channel: 2.31/edge
+    scale: 1
+    trust: true
+    _github_repo_name: dex-auth-operator
+  envoy:
+    charm: envoy
+    channel: 1.20/edge
+    scale: 1
+    _github_repo_name: envoy-operator
+  istio-ingressgateway:
+    charm: istio-gateway
+    channel: 1.11/edge
+    scale: 1
+    trust: true
+    _github_repo_name: istio-operators
+  istio-pilot:
+    charm: istio-pilot
+    channel: 1.11/edge
+    scale: 1
+    trust: true
+    _github_repo_name: istio-operators
+    options:
+      default-gateway: kubeflow-gateway
+  jupyter-controller:
+    charm: jupyter-controller
+    channel: 1.6/edge
+    scale: 1
+    _github_repo_name: notebook-operators
+  jupyter-ui:
+    charm: jupyter-ui
+    channel: 1.6/edge
+    scale: 1
+    _github_repo_name: notebook-operators
+  katib-controller:
+    charm: katib-controller
+    channel: 0.14/edge
+    scale: 1
+    _github_repo_name: katib-operators
+  katib-db:
+    charm: charmed-osm-mariadb-k8s
+    channel: latest/stable
+    scale: 1
+    options:
+      database: katib
+  katib-db-manager:
+    charm: katib-db-manager
+    channel: 0.14/edge
+    scale: 1
+    _github_repo_name: katib-operators
+  katib-ui:
+    charm: katib-ui
+    channel: 0.14/edge
+    scale: 1
+    _github_repo_name: katib-operators
+  kfp-api:
+    charm: kfp-api
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-db:
+    charm: charmed-osm-mariadb-k8s
+    channel: latest/stable
+    scale: 1
+    options:
+      database: mlpipeline
+  kfp-persistence:
+    charm: kfp-persistence
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-profile-controller:
+    charm: kfp-profile-controller
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-schedwf:
+    charm: kfp-schedwf
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-ui:
+    charm: kfp-ui
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-viewer:
+    charm: kfp-viewer
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kfp-viz:
+    charm: kfp-viz
+    channel: 2.0/edge
+    scale: 1
+    _github_repo_name: kfp-operators
+  kubeflow-dashboard:
+    charm: kubeflow-dashboard
+    channel: 1.6/edge
+    scale: 1
+    _github_repo_name: kubeflow-dashboard-operator
+  kubeflow-profiles:
+    charm: kubeflow-profiles
+    channel: 1.6/edge
+    scale: 1
+    _github_repo_name: kubeflow-profiles-operator
+  kubeflow-roles:
+    charm: kubeflow-roles
+    channel: 1.6/edge
+    scale: 1
+    trust: true
+    _github_repo_name: kubeflow-roles-operator
+  kubeflow-volumes:
+    charm: kubeflow-volumes
+    channel: 1.6/edge
+    scale: 1
+    _github_repo_name: kubeflow-volumes-operator
+  metacontroller-operator:
+    charm: metacontroller-operator
+    channel: 0.3/edge
+    scale: 1
+    trust: true
+    _github_repo_name: metacontroller-operator
+  mlmd:
+    charm: mlmd
+    channel: 1.0/edge
+    scale: 1
+    _github_repo_name: mlmd-operator
+  minio:
+    charm: minio
+    channel: latest/edge
+    scale: 1
+    _github_repo_name: minio-operator
+  oidc-gatekeeper:
+    charm: oidc-gatekeeper
+    channel: ckf-1.4/edge
+    scale: 1
+    _github_repo_name: oidc-gatekeeper-operator
+  seldon-controller-manager:
+    charm: seldon-core
+    channel: 1.14/edge
+    scale: 1
+    _github_repo_name: seldon-core-operator
+  tensorboard-controller:
+    charm: tensorboard-controller
+    channel: 1.6/edge
+    scale: 1
+    _github_repo_name: kubeflow-tensorboards-operator
+  tensorboards-web-app:
+    charm: tensorboards-web-app
+    channel: 1.6/edge
+    scale: 1
+    _github_repo_name: kubeflow-tensorboards-operator
+  training-operator:
+    charm: training-operator
+    channel: 1.5/edge
+    scale: 1
+    trust: true
+    _github_repo_name: training-operator
+relations:
+  - [argo-controller, minio]
+  - [dex-auth:oidc-client, oidc-gatekeeper:oidc-client]
+  - [istio-pilot:ingress, dex-auth:ingress]
+  - [istio-pilot:ingress, jupyter-ui:ingress]
+  - [istio-pilot:ingress, katib-ui:ingress]
+  - [istio-pilot:ingress, kfp-ui:ingress]
+  - [istio-pilot:ingress, kubeflow-dashboard:ingress]
+  - [istio-pilot:ingress, kubeflow-volumes:ingress]
+  - [istio-pilot:ingress, oidc-gatekeeper:ingress]
+  - [istio-pilot:ingress-auth, oidc-gatekeeper:ingress-auth]
+  - [istio-pilot:istio-pilot, istio-ingressgateway:istio-pilot]
+  - [istio-pilot:ingress, tensorboards-web-app:ingress]
+  - [istio-pilot:gateway, tensorboard-controller:gateway]
+  - [katib-db-manager, katib-db]
+  - [kfp-api, kfp-db]
+  - [kfp-api:kfp-api, kfp-persistence:kfp-api]
+  - [kfp-api:kfp-api, kfp-ui:kfp-api]
+  - [kfp-api:kfp-viz, kfp-viz:kfp-viz]
+  - [kfp-api:object-storage, minio:object-storage]
+  - [kfp-profile-controller:object-storage, minio:object-storage]
+  - [kfp-ui:object-storage, minio:object-storage]
+  - [kubeflow-profiles, kubeflow-dashboard]
+  - [mlmd:grpc, envoy:grpc]

--- a/releases/1.6/kubeflow-bundle.yaml
+++ b/releases/1.6/kubeflow-bundle.yaml
@@ -22,11 +22,6 @@ applications:
     scale: 1
     trust: true
     _github_repo_name: dex-auth-operator
-  envoy:
-    charm: envoy
-    channel: 1.20/edge
-    scale: 1
-    _github_repo_name: envoy-operator
   istio-ingressgateway:
     charm: istio-gateway
     channel: 1.11/edge
@@ -140,11 +135,6 @@ applications:
     scale: 1
     trust: true
     _github_repo_name: metacontroller-operator
-  mlmd:
-    charm: mlmd
-    channel: 1.0/edge
-    scale: 1
-    _github_repo_name: mlmd-operator
   minio:
     charm: minio
     channel: latest/edge

--- a/releases/1.6/mlflow.yaml
+++ b/releases/1.6/mlflow.yaml
@@ -1,0 +1,18 @@
+bundle: kubernetes
+name: mlflow-overlay
+applications:
+  mlflow-server:
+    charm: mlflow-server
+    channel: 1.13/stable
+    scale: 1
+    _github_repo_name: mlflow-operator
+  mlflow-db:
+    charm: charmed-osm-mariadb-k8s
+    channel: latest/stable
+    scale: 1
+    options:
+      database: mlflow
+relations:
+  - [mlflow-server, mlflow-db]
+  - [mlflow-server, minio]
+  - [mlflow-server, istio-pilot]

--- a/releases/1.6/spark.yaml
+++ b/releases/1.6/spark.yaml
@@ -1,0 +1,8 @@
+bundle: kubernetes
+name: spark
+applications:
+  spark:
+    charm: spark-k8s
+    channel: 3.1/stable
+    scale: 1
+    _github_repo_name: spark-operator

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8<4.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins


### PR DESCRIPTION
This PR adds the bundle files for the kubeflow 1.6 release that pull from each charm's invidual track in the edge risk.  

