### PR TITLE
fix: corrects metacontroller-operator track version 0.3->2.0

### DIFF
--- a/releases/1.6/kubeflow-bundle.yaml
+++ b/releases/1.6/kubeflow-bundle.yaml
@@ -131,7 +131,7 @@ applications:
     _github_repo_name: kubeflow-volumes-operator
   metacontroller-operator:
     charm: metacontroller-operator
-    channel: 0.3/edge
+    channel: 2.0/edge
     scale: 1
     trust: true
     _github_repo_name: metacontroller-operator


### PR DESCRIPTION
metacontroller-operator is now updated to 2.0. Please do not merge this PR before the track has been created. 
Follow [this](https://discourse.charmhub.io/t/request-add-track-2-0-to-metacontroller-operator/6895) thread for status updates.