### PR TITLE
Add kind option to istio-ingressgateway

### DIFF
--- a/releases/1.6/kubeflow-bundle.yaml
+++ b/releases/1.6/kubeflow-bundle.yaml
@@ -28,6 +28,8 @@ applications:
     scale: 1
     trust: true
     _github_repo_name: istio-operators
+    options:
+      kind: ingress
   istio-pilot:
     charm: istio-pilot
     channel: 1.11/edge


### PR DESCRIPTION
Forgot about the kind option in the 1.6 releases directory.