### PR TITLE
changes on bundle definition to match canonical/bundle-kubeflow

### DIFF
--- a/releases/1.6/kubeflow-bundle.yaml
+++ b/releases/1.6/kubeflow-bundle.yaml
@@ -144,7 +144,7 @@ applications:
     _github_repo_name: minio-operator
   oidc-gatekeeper:
     charm: oidc-gatekeeper
-    channel: ckf-1.4/edge
+    channel: ckf-1.6/edge
     scale: 1
     _github_repo_name: oidc-gatekeeper-operator
   seldon-controller-manager:


### PR DESCRIPTION
oidc-gatekeeper -> ckf-1.6/edge

