### PR TITLE
Deploy function with basic tox setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
 markers = [
     "v1dot4: bundle 1.4 tests",
     "v1dot6: bundle 1.6 tests",
-    "full_bundle_shared: tests that are shared in all versions of full bundle",
-    "lite_bundle_shared: tests that are shared in all versions of lite bundle"
+    "full: tests that are shared in all versions of full bundle",
+    "lite: tests that are shared in all versions of lite bundle"
 
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,12 @@ docstring-convention = "google"
 copyright-check = "True"
 copyright-author = "Canonical Ltd."
 copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+
+[tool.pytest.ini_options]
+markers = [
+    "v1dot4: bundle 1.4 tests",
+    "v1dot6: bundle 1.6 tests",
+    "full_bundle_shared: tests that are shared in all versions of full bundle",
+    "lite_bundle_shared: tests that are shared in all versions of lite bundle"
+
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ def deploy_cmd(request, ops_test):
     bundle_file = request.config.getoption("file", default=None)
     channel = request.config.getoption("channel", default=None)
 
-    if (bundle_file is None and channel is None) or (bundle_file and channel):
+    if (not bundle_file and not channel) or (bundle_file and channel):
         raise ValueError("One of --file or --channel is required")
 
     model = ops_test.model_full_name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+from _pytest.config.argparsing import Parser
+
+
+def pytest_addoption(parser: Parser):
+    parser.addoption(
+        "--file",
+        help="Path to bundle file to use as the template for tests.  This must include all charms"
+        "built by this bundle, where the locally built charms will replace those specified. "
+        "This is useful for testing this bundle against different external dependencies. "
+        "e.g. ./releases/1.6/kubeflow-bundle.yaml",
+    )
+
+    parser.addoption(
+        "--channel",
+        help="Kubeflow channels, e.g. latest/stable, 1.6/beta",
+    )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,15 @@
+def get_ingress_url(lightkube_client, model_name):
+    gateway_svc = lightkube_client.get(
+        Service, "istio-ingressgateway-workload", namespace=model_name
+    )
+
+    public_url = f"http://{gateway_svc.status.loadBalancer.ingress[0].ip}.nip.io"
+    return public_url
+
+
+async def get_ingress_ip_1dot4(ops_test):
+    status = await ops_test.model.get_status()
+    public_url = (
+        f"http://{status['applications']['istio-ingressgateway']['public-address']}.nip.io"
+    )
+    return public_url

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -15,7 +15,7 @@ PASSWORD = "foobar"
 @pytest.mark.v1dot6
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed
-async def test_deploy_1dot6(ops_test, lightkube_client, deploy_cmd):
+async def test_deploy_1dot6(ops_test: OpsTest, lightkube_client, deploy_cmd):
     print(f"Deploying bundle to {ops_test.model_full_name} using cmd '{deploy_cmd}'")
     rc, stdout, stderr = await ops_test.run(*shlex.split(deploy_cmd))
 
@@ -45,7 +45,7 @@ async def test_deploy_1dot6(ops_test, lightkube_client, deploy_cmd):
 @pytest.mark.v1dot4
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed
-async def test_deploy_1dot4(ops_test, lightkube_client, deploy_cmd):
+async def test_deploy_1dot4(ops_test: OpsTest, lightkube_client, deploy_cmd):
     print(f"Deploying bundle to {ops_test.model_full_name} using cmd '{deploy_cmd}'")
     rc, stdout, stderr = await ops_test.run(*shlex.split(deploy_cmd))
 
@@ -56,17 +56,15 @@ async def test_deploy_1dot4(ops_test, lightkube_client, deploy_cmd):
         timeout=1800,
     )
 
-    await ops_test.model.set_config({"update-status-hook-interval": "15s"})
-    istio_gateway_role_name = "istio-ingressgateway-operator"
-
     print("Patch role for istio-gateway")
-    new_policy_rule = PolicyRule(verbs=["*"], apiGroups=["*"], resources=["*"])
-    this_role = lightkube_client.get(Role, istio_gateway_role_name)
-    this_role.rules.append(new_policy_rule)
-    lightkube_client.patch(Role, istio_gateway_role_name, this_role)
+    async with ops_test.fast_forward(fast_interval="15s"):
+        istio_gateway_role_name = "istio-ingressgateway-operator"
+        new_policy_rule = PolicyRule(verbs=["*"], apiGroups=["*"], resources=["*"])
+        this_role = lightkube_client.get(Role, istio_gateway_role_name)
+        this_role.rules.append(new_policy_rule)
 
-    time.sleep(50)
-    await ops_test.model.set_config({"update-status-hook-interval": "5m"})
+        lightkube_client.patch(Role, istio_gateway_role_name, this_role)
+        time.sleep(50)
 
     print("Waiting for bundle to be ready")
     await ops_test.model.wait_for_idle(

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1,0 +1,72 @@
+import pytest
+import shlex
+from pytest_operator.plugin import OpsTest
+import lightkube
+from lightkube.resources.core_v1 import Service
+
+USERNAME = "admin"
+PASSWORD = "foobar"
+
+
+def get_ingress_ip(lightkube_client, model_name):
+    gateway_svc = lightkube_client.get(
+        Service, "istio-ingressgateway-workload", namespace=model_name
+    )
+
+    endpoint = gateway_svc.status.loadBalancer.ingress[0].ip
+    return endpoint
+
+
+@pytest.fixture(scope="session")
+def lightkube_client():
+    yield lightkube.Client()
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
+async def test_deploy(ops_test, request, lightkube_client):
+    if ops_test.model_name != "kubeflow":
+        raise ValueError("kfp must be deployed to namespace kubeflow")
+
+    bundle_file = request.config.getoption("file", default=None)
+    channel = request.config.getoption("channel", default=None)
+
+    if (bundle_file is None and channel is None) or (bundle_file and channel):
+        raise ValueError("One of --file or --channel is required")
+
+    model = ops_test.model_full_name
+
+    if bundle_file:
+        # pytest automatically prune path to relative paths without `./`
+        # juju deploys requires `./`
+        cmd = f"juju deploy -m {model} --trust ./{bundle_file}"
+    if channel:
+        cmd = f"juju deploy kubeflow -m {model} --trust --channel {channel}"
+
+    print(f"Deploying bundle to {model} using cmd '{cmd}'")
+    rc, stdout, stderr = await ops_test.run(*shlex.split(cmd))
+    if stderr:
+        print(stderr)
+        raise RuntimeError("failed to deploy")
+
+    print("Waiting for bundle to be ready")
+    await ops_test.model.wait_for_idle(
+        status="active",
+        raise_on_blocked=False,
+        raise_on_error=True,
+        timeout=3000,
+    )
+    endpoint = get_ingress_ip(lightkube_client, ops_test.model_name)
+    url = f"http://{endpoint}.nip.io"
+
+    await ops_test.model.applications["dex-auth"].set_config(
+        {"public-url": url, "static-username": USERNAME, "static-password": PASSWORD}
+    )
+    await ops_test.model.applications["oidc-gatekeeper"].set_config({"public-url": url})
+
+    await ops_test.model.wait_for_idle(
+        status="active",
+        raise_on_blocked=False,
+        raise_on_error=True,
+        timeout=600,
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -71,10 +71,19 @@ deps =
 commands = 
   pytest -v --tb native {[vars]scripts_test_path}/test_branch_track_creation.py --log-cli-level=INFO -s {posargs}
 
-[testenv:test_releases]
+[testenv:test_1dot4]
 description = Test bundles
 deps = 
   lightkube
   pytest
   pytest-operator
-commands = pytest -vs --tb native {[vars]releases_test_path} {posargs} --model kubeflow
+commands = pytest -vs --tb native {[vars]releases_test_path} -m "v1dot4" --model kubeflow {posargs}
+
+
+[testenv:test_1dot6]
+description = Test bundles
+deps = 
+  lightkube
+  pytest
+  pytest-operator
+commands = pytest -vs --tb native {[vars]releases_test_path} -m "v1dot6" --model kubeflow {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = lint, unit
 
 [vars]
 releases_path = {toxinidir}/releases/
+releases_test_path = {toxinidir}/tests/
 scripts_path = {toxinidir}/scripts/
 scripts_test_path = {toxinidir}/scripts/tests
 all_path = {[vars]releases_path} {[vars]scripts_path}  {[vars]scripts_test_path}
@@ -69,3 +70,11 @@ deps =
   pytest-mock
 commands = 
   pytest -v --tb native {[vars]scripts_test_path}/test_branch_track_creation.py --log-cli-level=INFO -s {posargs}
+
+[testenv:test_releases]
+description = Test bundles
+deps = 
+  lightkube
+  pytest
+  pytest-operator
+commands = pytest -vs --tb native {[vars]releases_test_path} {posargs} --model kubeflow

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ releases_path = {toxinidir}/releases/
 releases_test_path = {toxinidir}/tests/
 scripts_path = {toxinidir}/scripts/
 scripts_test_path = {toxinidir}/scripts/tests
-all_path = {[vars]releases_path} {[vars]scripts_path}  {[vars]scripts_test_path}
+all_path = {[vars]releases_path} {[vars]releases_test_path} {[vars]scripts_path} {[vars]scripts_test_path}
 
 [testenv]
 setenv =
@@ -26,8 +26,8 @@ deps =
     black
     isort
 commands =
-    isort {[vars]scripts_path}
-    black {[vars]scripts_path}
+    isort {[vars]all_path}
+    black {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
@@ -46,8 +46,8 @@ commands =
       --skip {toxinidir}/cannon_runs --skip {toxinidir}/venv
     # pflake8 wrapper supports config from pyproject.toml
     pflake8 {[vars]scripts_path}
-    isort --check-only --diff {[vars]scripts_path}
-    black --check --diff {[vars]scripts_path}
+    isort --check-only --diff {[vars]all_path}
+    black --check --diff {[vars]all_path}
 
 [testenv:branch_track_creation]
 description = Run branch and track creation script


### PR DESCRIPTION
test function for deploying kubeflow bundle. It accepts either `--file` or `--channel` as input.
1.4 and 1.6 use different deploy function because istio-ingressgateway role needs to be patched in 1.4. There are also separate get ingress url helper functions.
```
tox -e test_1dot4 -- --file ./releases/1.4/kubeflow-bundle.yaml
tox -e test_1dot6 -- --channel 1.6/beta
```