### PR TITLE
add a batch operation for bumping image versions

### DIFF
--- a/cannon_runs/2022-08-31_batch_bump_versions/README.md
+++ b/cannon_runs/2022-08-31_batch_bump_versions/README.md
@@ -1,0 +1,13 @@
+# Summary 
+The purpose of this batch operation is to bump versions of some of our common images, typically like when we bump from one release candidate to another. To use, modify the tag patterns in `main.sh` to handle the previous/new tagging.
+
+# Execution details
+
+This is a batch update to our repos completed using [git-xargs](https://github.com/gruntwork-io/git-xargs).  Execution was completed using commands listed in `run_git-xargs.sh`.
+
+`git-xargs` executes the script you provide to modify one or more repos.  It:
+* pulls each repo
+* executes the provided script in the root dir of each repo
+* creates PRs for each change
+* tries to handle rate limiting issues from GitHub
+

--- a/cannon_runs/2022-08-31_batch_bump_versions/main.sh
+++ b/cannon_runs/2022-08-31_batch_bump_versions/main.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -x
+
+# This script:
+# * finds and bumps image versions in metadata.yamls if they fit a pattern
+# * bumps image versions in the jupyter-ui spawner config
+
+# Get the absolute path to where this script lives, so we can copy files
+# from here without knowing that path ahead of runtime.
+# Taken from https://stackoverflow.com/a/4774063/5394584
+# Seems like there's cases where this might not work, but generally good?
+SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+echo "Copying source files from '$SCRIPTPATH'"
+
+echo "I am executing this script from $(pwd)"
+
+# Glob pattern to match all metadata.yaml files
+METADATA_FILE_PATTERN="**/metadata.yaml"
+
+# Kubeflow (matches any image using the standard kubeflow release versioning)
+TAG_OLD_PATTERN="\([^:]*\):v1.6.0-rc.[0-9]\{1,\}"
+TAG_NEW="\1:v1.6.0-rc.2"
+find . -type f -wholename "$METADATA_FILE_PATTERN" -exec sed -i "s/$TAG_OLD_PATTERN/$TAG_NEW/g" {} \;
+# Jupyter ui's spawner config
+sed -i "s/$TAG_OLD_PATTERN/$TAG_NEW/g" ./charms/jupyter-ui/src/spawner_ui_config.yaml
+
+# KFP
+TAG_OLD_PATTERN="\(gcr.io\/ml-pipeline\/[^:]*\):2.0.0-alpha.[0-9]\{1,\}"
+TAG_NEW="\1:2.0.0-alpha.3"
+find . -type f -wholename "$METADATA_FILE_PATTERN" -exec sed -i "s/$TAG_OLD_PATTERN/$TAG_NEW/g" {} \;
+
+# KServe
+TAG_OLD_PATTERN="\(kserve\/[^:]*\):v[0-9]\{1,\}.[0-9]\{1,\}.[0-9]\{1,\}"
+TAG_NEW="\1:v0.8.0"
+find . -type f -wholename "$METADATA_FILE_PATTERN" -exec sed -i "s/$TAG_OLD_PATTERN/$TAG_NEW/g" {} \;
+
+# Training Operator
+TAG_OLD_PATTERN="\(kubeflow\/training-operator\):v[0-9]\{1,\}-[a-z0-9]\{1,\}"
+TAG_NEW="\1:v1-e1434f6"
+find . -type f -wholename "$METADATA_FILE_PATTERN" -exec sed -i "s/$TAG_OLD_PATTERN/$TAG_NEW/g" {} \;
+
+# Katib
+TAG_OLD_PATTERN="\(docker.io\/kubeflowkatib\/[^:]*\):v[0-9]\{1,\}.[0-9]\{1,\}.[0-9]\{1,\}-rc.[0-9]\{1,\}"
+TAG_NEW="\1:0.14.0-rc.0"
+find . -type f -wholename "$METADATA_FILE_PATTERN" -exec sed -i "s/$TAG_OLD_PATTERN/$TAG_NEW/g" {} \;
+# Katib also has images in several JSON files
+find . -type f -wholename "./charms/katib-controller/src/*.json" -exec sed -i "s/$TAG_OLD_PATTERN/$TAG_NEW/g" {} \;

--- a/cannon_runs/2022-08-31_batch_bump_versions/main.sh
+++ b/cannon_runs/2022-08-31_batch_bump_versions/main.sh
@@ -4,6 +4,7 @@ set -x
 # This script:
 # * finds and bumps image versions in metadata.yamls if they fit a pattern
 # * bumps image versions in the jupyter-ui spawner config
+# * bumps image versions in the katib suggestions config
 
 # Get the absolute path to where this script lives, so we can copy files
 # from here without knowing that path ahead of runtime.

--- a/cannon_runs/2022-08-31_batch_bump_versions/repos.txt
+++ b/cannon_runs/2022-08-31_batch_bump_versions/repos.txt
@@ -1,4 +1,8 @@
 # Generated using `gh search repos --topic charmed-kubeflow | awk '{print $1}' > repos.txt`
+# Note that this list was all charms as of this run, but if running this in future you should build
+# your own list as new repositories may have been added.  
+# This execution used the entire list, but if you know you only need to search a subset of the
+# repos you could filter this list first. 
 canonical/bundle-kubeflow
 canonical/mlflow-operator
 canonical/istio-operators

--- a/cannon_runs/2022-08-31_batch_bump_versions/repos.txt
+++ b/cannon_runs/2022-08-31_batch_bump_versions/repos.txt
@@ -1,0 +1,26 @@
+# Generated using `gh search repos --topic charmed-kubeflow | awk '{print $1}' > repos.txt`
+canonical/bundle-kubeflow
+canonical/mlflow-operator
+canonical/istio-operators
+canonical/seldon-core-operator
+canonical/notebook-operators
+canonical/training-operator
+canonical/kubeflow-ci
+canonical/envoy-operator
+canonical/kserve-operators
+canonical/minio-operator
+canonical/kfp-operators
+canonical/kubeflow-profiles-operator
+canonical/knative-operators
+canonical/charmed-kubeflow-chisme
+canonical/admission-webhook-operator
+canonical/kubeflow-roles-operator
+canonical/kubeflow-dashboard-operator
+canonical/metacontroller-operator
+canonical/mlmd-operator
+canonical/kubeflow-tensorboards-operator
+canonical/argo-operators
+canonical/katib-operators
+canonical/oidc-gatekeeper-operator
+canonical/kubeflow-volumes-operator
+canonical/dex-auth-operator

--- a/cannon_runs/2022-08-31_batch_bump_versions/run_git-xargs.sh
+++ b/cannon_runs/2022-08-31_batch_bump_versions/run_git-xargs.sh
@@ -1,0 +1,16 @@
+# Get the absolute path to where this script lives, so we can copy files
+# from here without knowing that path ahead of runtime.
+# Taken from https://stackoverflow.com/a/4774063/5394584
+# Seems like there's cases where this might not work, but generally good?
+SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+# Execute
+# during testing, use:
+#   --loglevel DEBUG --dry-run --draft\
+# NOTE: The script path passed as the positional arg below must be absolute, not relative
+git-xargs \
+  --dry-run --loglevel DEBUG\
+  --repos repos.txt \
+  --branch-name add-codeowners-file \
+  --pull-request-title "ci: Add a CODEOWNERS file" \
+  bash $SCRIPTPATH/main.sh


### PR DESCRIPTION
This is a batch operation using git-xargs to apply sed across our repos and bump common image versions.  Typical use would be to bump from one RC to another.

See README.md for more details
