### PR TITLE
add scripts for batch releasing charms

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -10,6 +10,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt update && sudo apt install tox
+      # temporarily allow to ssh to debug this action
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 20
+
       - run: tox -e lint
 
   branch_creation_tests:

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -19,3 +19,11 @@ jobs:
       - uses: actions/checkout@v2
       - run: sudo apt update && sudo apt install tox
       - run: tox -e test_branch_creation
+
+  batch_release_charms_tests:
+    name: Batch Release Charms Script Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt update && sudo apt install tox
+      - run: tox -e test_batch_release_charms

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -10,11 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt update && sudo apt install tox
-      # temporarily allow to ssh to debug this action
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 20
-
       - run: tox -e lint
 
   branch_creation_tests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ line-length = 99
 target-version = ["py38"]
 
 [tool.isort]
+line_length = 99
 profile = "black"
 
 # Linting tools configuration
@@ -13,7 +14,7 @@ profile = "black"
 max-line-length = 99
 max-doc-length = 99
 max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
+exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "scripts"]
 select = ["E", "W", "F", "C", "N", "R", "D", "H"]
 # Ignore W503, E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__

--- a/scripts/release-charms/README.md
+++ b/scripts/release-charms/README.md
@@ -1,0 +1,7 @@
+# Summary
+
+Script to release multiple charms at once
+
+# Usage
+
+TODO

--- a/scripts/release-charms/README.md
+++ b/scripts/release-charms/README.md
@@ -121,3 +121,10 @@ GITHUB_PAT=SOME_GITHUB_PAT python workflow_dispatcher.py dispatch_manifest.yaml 
 ```
 
 where `SOME_GITHUB_PAT` is a Github Personal Access Token that is allowed to create workflow dispatches on the repositories in the manifest.  This will result in the tool executing each one and waiting for them to complete.  
+
+## Testing
+
+To run the tests, from the root of this repo do:
+```bash
+tox -e test_batch_release_charms
+```

--- a/scripts/release-charms/README.md
+++ b/scripts/release-charms/README.md
@@ -1,7 +1,123 @@
 # Summary
 
-Script to release multiple charms at once
+create_release_workflow_dispatch_manifest.py and workflow_dispatcher.py are scripts that together make it easier to batch-release many charms from one channel to another:
+* workflow_dispatcher.py: accepts a YAML list of Github workflow dispatches and their inputs to execute, and executes them
+* create_release_workflow_dispatch_manifest.py: inspects two bundle files (say `source` and `destination`) and computes all the release workflow dispatches that are needed to release charms in channels mentioned in `source` to the channels in `destination`.  These dispatches are output in the YAML format required by workflow_dispatcher.py
 
-# Usage
+# create_release_workflow_dispatch_manifest.py
 
-TODO
+## Usage
+
+Given the two bundle files:
+
+source.yaml:
+```yaml
+bundle: kubernetes
+name: kubeflow-lite
+applications:
+  # This charm is a single-charm repo, but is not owned by us (we do not 
+  # add our _github_repo_name variable) and will be skipped
+  single-not-our-charm:
+    charm: single-not-our-charm-charm
+    channel: 1.6/edge
+    scale: 1
+  # This charm will create a release from 1.6/edge to 1.6/stable
+  single-should-release:
+    charm: single-should-release-charm
+    channel: 1.6/edge
+    scale: 1
+    _github_repo_name: single-should-release-repo  # Eg: github.com/canonical/single-should-release-repo
+  # This charm from a multi-charm repo will create a release from 1.6/edge to 1.6/stable
+  multi-should-release:
+    charm: multi-should-release-charm
+    channel: 1.6/edge
+    scale: 1
+    _github_repo_name: multi-should-release-repo
+    _path_in_github_repo: charms/multi-should-release-charm
+  # This charm does not need a release (both source and destination use channel=1.6/stable
+  multi-no-release-needed:
+    charm: multi-no-release-needed-charm
+    channel: 1.6/stable
+    scale: 1
+    _github_repo_name: notebook-operators
+    _path_in_github_repo: charms/jupyter-controller
+```
+
+and `destination.yaml`:
+```yaml
+bundle: kubernetes
+name: kubeflow-lite
+applications:
+  single-not-our-charm:
+    charm: single-not-our-charm-charm
+    channel: 1.6/stable
+    scale: 1
+  single-should-release:
+    charm: single-should-release-charm
+    channel: 1.6/stable
+    scale: 1
+    _github_repo_name: single-should-release-repo
+  multi-should-release:
+    charm: multi-should-release-charm
+    channel: 1.6/stable
+    scale: 1
+    _github_repo_name: multi-should-release-repo
+    _path_in_github_repo: charms/multi-should-release-charm
+  multi-no-release-needed:
+    charm: multi-no-release-needed-charm
+    channel: 1.6/stable
+    scale: 1
+    _github_repo_name: notebook-operators
+    _path_in_github_repo: charms/jupyter-controller
+```
+
+If we execute `create_release_workflow_dispatch_manifest.py source.yaml destination.yaml`, we get the output `dispatch_manifest.yaml` file:
+
+```yaml
+- inputs:
+    destination-channel: 1.6/stable
+    origin-channel: 1.6/edge
+  repository: canonical/single-should-release-repo
+  workflow_name: release.yaml
+- inputs:
+    charm-name: multi-should-release-charm
+    destination-channel: 1.6/stable
+    origin-channel: 1.6/edge
+  repository: canonical/multi-should-release-repo
+  workflow_name: release.yaml
+```
+
+which has two workflow dispatches, one for each charm that needs a release.
+
+# workflow_dispatcher.py
+
+workflow_dispatcher.py executes one or more workflow dispatches, waiting on each to complete before moving on to the next.  Inputs are specified in a YAML list of the format:
+
+```yaml
+- repository: owner/repository-name # Repo where workflow will be dispatched
+  workflow_name: some-workflow.yaml # Workflow to dispatch
+  inputs: # Inputs to the workflow
+    input1: value1
+    input2: value2
+```
+
+## Usage
+
+Given the file `dispatch_manifest.yaml` from the previous example, we can execute the workflow dispatches with:
+```bash
+workflow_dispatcher.py workflow_dispatch.yaml
+```
+
+This will by default execute a dry-run of the operation, outputting:
+
+```
+INFO:__main__:Dry run: would execute workflow release.yaml in repository canonical/single-should-release-repo with inputs {'destination-channel': '1.6/stable', 'origin-channel': '1.6/edge'}
+INFO:__main__:Dry run: would execute workflow release.yaml in repository canonical/multi-should-release-repo with inputs {'charm-name': 'multi-should-release-charm', 'destination-channel': '1.6/stable', 'origin-channel': '1.6/edge'}
+```
+
+where we see the actions that would be taken.  If we like these actions, we can execute again using: 
+```bash
+GITHUB_PAT=SOME_GITHUB_PAT python workflow_dispatcher.py dispatch_manifest.yaml --no-dry-run
+```
+
+where `SOME_GITHUB_PAT` is a Github Personal Access Token that is allowed to create workflow dispatches on the repositories in the manifest.  This will result in the tool executing each one and waiting for them to complete.  

--- a/scripts/release-charms/create_release_workflow_dispatch_manifest.py
+++ b/scripts/release-charms/create_release_workflow_dispatch_manifest.py
@@ -1,3 +1,9 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Creates a workflow dispatch manifest to release charms from one bundle to another."""
+
 import logging
 from pathlib import Path
 import yaml
@@ -32,9 +38,7 @@ def main(
         help="Name of the output YAML file to write the dispatch manifest to",
     ),
 ):
-    """
-    Create a workflow dispatch manifest from Charm Bundle files.
-    """
+    """Create a workflow dispatch manifest from Charm Bundle files."""
     source_bundle = Bundle(source_bundle)
     destination_bundle = Bundle(destination_bundle)
 
@@ -102,7 +106,6 @@ def get_matching_application(source_application_name, source_application, destin
 
 def get_repository(source_application, destination_application) -> str:
     """Returns the repository string for this charm, including owner"""
-
     try:
         # Check for the inputs we add to the charms we manage in our bundle files, adding
         # a default for owner if it is omitted
@@ -111,7 +114,7 @@ def get_repository(source_application, destination_application) -> str:
         destination_repository = f'{destination_application.get("_github_repo_owner", "canonical")}/' \
                                  f'{destination_application["_github_repo_name"]}'
 
-    except KeyError as e:
+    except KeyError:
         raise ApplicationMatchError(
             f"Application would have been released from {source_application['channel']}->"
             f"{destination_application['channel']}, but one or both are missing the required "
@@ -129,7 +132,6 @@ def get_repository(source_application, destination_application) -> str:
 
 def get_path_in_repo(source_application, destination_application) -> str:
     """Returns the charm path within the repo, if they match, else raises ValueError"""
-
     source_path_in_repo = Path(source_application.get("_path_in_github_repo", "./"))
     destination_path_in_repo = Path(destination_application.get("_path_in_github_repo", "./"))
     if source_path_in_repo != destination_path_in_repo:

--- a/scripts/release-charms/create_release_workflow_dispatch_manifest.py
+++ b/scripts/release-charms/create_release_workflow_dispatch_manifest.py
@@ -1,0 +1,202 @@
+import logging
+from pathlib import Path
+import yaml
+
+import typer
+
+from charmed_kubeflow_chisme.bundle import Bundle
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def main(
+    source_bundle: str = typer.Argument(
+        ...,
+        help="Path to a file defining the source channel for releases.  The file format "
+        "expected is a standard bundle YAML file, where any charm that is in-scope for generating"
+        "a release should also have the _github_repo_name key.  Additionally, if the charm is from"
+        "a multi-charm repo, it should also include a _path_in_github_repo of the relative path"
+        "to that charm in the repo, for example 'charms/my-charm'",
+    ),
+    destination_bundle: str = typer.Argument(
+        ...,
+        help="Path to a file defining the destination channel for releases.  The file format "
+             "expected is a standard bundle YAML file, where any charm that is in-scope for generating"
+             "a release should also have the _github_repo_name key.  Additionally, if the charm is from"
+             "a multi-charm repo, it should also include a _path_in_github_repo of the relative path"
+             "to that charm in the repo, for example 'charms/my-charm'",
+    ),
+    output_file: str = typer.Option(
+        default="dispatch_manifest.yaml",
+        help="Name of the output YAML file to write the dispatch manifest to",
+    ),
+):
+    """
+    Create a workflow dispatch manifest from Charm Bundle files.
+    """
+    source_bundle = Bundle(source_bundle)
+    destination_bundle = Bundle(destination_bundle)
+
+    release_dispatches = []
+
+    for source_application_name, source_application in source_bundle.applications.items():
+
+        # Find a matching application in the destination bundle
+        try:
+            validate_application_in_scope(source_application_name, source_application)
+            destination_application = get_matching_application(source_application_name, source_application, destination_bundle)
+            logger.info(
+                f"Application {source_application_name} found in both bundles and requiring release."
+            )
+            repository = get_repository(source_application, destination_application)
+            path_in_repo = get_path_in_repo(source_application, destination_application)
+        except ApplicationMatchError as e:
+            logger.info(str(e) + "  Skipping.")
+            continue
+
+        dispatch = build_release_dispatch_dict(source_application, destination_application, repository, path_in_repo)
+        logger.info(
+            f"Application {source_application_name} causing release of charm {source_application['charm']} from {dispatch['inputs']['origin-channel']}->{dispatch['inputs']['destination-channel']}")
+        release_dispatches.append(dispatch)
+
+    write_output(release_dispatches, output_file)
+
+
+class ApplicationMatchError(Exception):
+    """Raised when the source and destination applications are not a match for release."""
+    pass
+
+
+def get_matching_application(source_application_name, source_application, destination_bundle) -> bool:
+    """Returns matching destination app if one matches, will be released, and has needed data.
+
+    Otherwise, it raises ValueError with the reason for rejection.
+
+    The applications constitute a release if:
+    * they reference the same charm
+    * they reference different channels
+    """
+    try:
+        destination_application = destination_bundle.applications[source_application_name]
+    except KeyError:
+        raise ApplicationMatchError(
+            f"Application {source_application_name} not found in destination bundle."
+        )
+
+    if source_application["charm"] != destination_application["charm"]:
+        raise ApplicationMatchError(
+            f"Source and destination charms for application {source_application_name} do not match"
+            f".  Got {source_application['charm']}, {destination_application['charm']}, "
+            f"respectively."
+        )
+
+    if source_application["channel"] == destination_application["channel"]:
+        raise ApplicationMatchError(
+            f"Source and destination for application {source_application_name} both reference the "
+            f"same channel."
+        )
+
+    return destination_application
+
+
+def get_repository(source_application, destination_application) -> str:
+    """Returns the repository string for this charm, including owner"""
+
+    try:
+        # Check for the inputs we add to the charms we manage in our bundle files, adding
+        # a default for owner if it is omitted
+        source_repository = f'{source_application.get("_github_repo_owner", "canonical")}/' \
+                            f'{source_application["_github_repo_name"]}'
+        destination_repository = f'{destination_application.get("_github_repo_owner", "canonical")}/' \
+                                 f'{destination_application["_github_repo_name"]}'
+
+    except KeyError as e:
+        raise ApplicationMatchError(
+            f"Application would have been released from {source_application['channel']}->"
+            f"{destination_application['channel']}, but one or both are missing the required "
+            f"additional variable _github_repo_name"
+        )
+
+    if source_repository != destination_repository:
+        raise ValueError(
+            f"Source and destination repositories do not match.  Got {source_repository} and"
+            f"destination ({destination_repository}, respectively."
+        )
+
+    return source_repository
+
+
+def get_path_in_repo(source_application, destination_application) -> str:
+    """Returns the charm path within the repo, if they match, else raises ValueError"""
+
+    source_path_in_repo = Path(source_application.get("_path_in_github_repo", "./"))
+    destination_path_in_repo = Path(destination_application.get("_path_in_github_repo", "./"))
+    if source_path_in_repo != destination_path_in_repo:
+        raise ValueError(
+            f"Source and destination _path_in_github_repo do not match.  Got {str(source_path_in_repo)}) and "
+            f"{str(destination_path_in_repo)}, respectively."
+        )
+
+    if source_path_in_repo.is_absolute():
+        raise ValueError(
+            f"_path_in_github_repo variable must be a relative"
+            f"path to the top of the Github repository.  Got '({str(source_path_in_repo)})'"
+        )
+
+    return source_path_in_repo
+
+
+def build_release_dispatch_dict(source_application, destination_application, repository, path_in_repo) -> dict:
+    """Returns a dict representing a workflow dispatch run"""
+    dispatch = {
+        'repository': repository,
+        'workflow_name': 'release.yaml',
+        'inputs': {
+            'origin-channel': source_application['channel'],
+            'destination-channel': destination_application['channel'],
+        }
+    }
+
+    # If we are a multi-charm repo, add the charm-name
+    if path_in_repo == Path('.'):
+        # Charm is in the Github repo root, so this is a single-charm repo
+        # Do not add the charm-name to inputs
+        pass
+    else:
+        # Validate the charm path to ensure it follows the hard-coded assumptions of the
+        # release.yaml workflow
+        if len(path_in_repo.parts) != 2 or path_in_repo.parts[0] != 'charms':
+            raise ValueError(
+                f"Due to assumptions in the release.yaml action for multi-charm repos,"
+                f" the _path_in_github_repo variable must be one "
+                " of the following: './' or './charms/<charm-name>'.  "
+                f"Got '{str(path_in_repo)}'"
+            )
+        dispatch['inputs']['charm-name'] = path_in_repo.name
+    return dispatch
+
+
+def write_output(dispatches, output_file: str):
+    """Writes the release dispatches to the output file"""
+    with open(output_file, 'w') as f:
+        yaml.dump(dispatches, f, indent=2)
+
+
+def validate_application_in_scope(name, app):
+    """Checks that the app is in scope (managed by our team), else raises ApplicationMatchError
+
+    Application is considered in scope if it has the mandatory additional variables we set in out
+    bundles:
+    * _github_repo_name
+    """
+    for var in ['_github_repo_name']:
+        if var not in app:
+            raise ApplicationMatchError(
+                f"Application {name} is missing required variable {var} and likely is not "
+                f"controlled by our team."
+            )
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/scripts/release-charms/requirements.txt
+++ b/scripts/release-charms/requirements.txt
@@ -1,0 +1,8 @@
+# TODO: Point this to somewhere shared
+# charmed-kubeflow-chisme
+# git+https://github.com/canonical/charmed-kubeflow-chisme.git@add-bundle-tools  # Hack while it is not merged
+-e /home/scribs/code/canonical/charmed-kubeflow-chisme/add-bundle-tools  # Hack while developing locally
+PyGithub
+pytest
+pytest-mock
+typer

--- a/scripts/release-charms/requirements.txt
+++ b/scripts/release-charms/requirements.txt
@@ -3,6 +3,4 @@
 # git+https://github.com/canonical/charmed-kubeflow-chisme.git@add-bundle-tools  # Hack while it is not merged
 -e /home/scribs/code/canonical/charmed-kubeflow-chisme/add-bundle-tools  # Hack while developing locally
 PyGithub
-pytest
-pytest-mock
 typer

--- a/scripts/release-charms/requirements.txt
+++ b/scripts/release-charms/requirements.txt
@@ -1,6 +1,3 @@
-# TODO: Point this to somewhere shared
-# charmed-kubeflow-chisme
-# git+https://github.com/canonical/charmed-kubeflow-chisme.git@add-bundle-tools  # Hack while it is not merged
--e /home/scribs/code/canonical/charmed-kubeflow-chisme/add-bundle-tools  # Hack while developing locally
+charmed-kubeflow-chisme
 PyGithub
 typer

--- a/scripts/release-charms/test_workflow_dispatcher.py
+++ b/scripts/release-charms/test_workflow_dispatcher.py
@@ -1,0 +1,210 @@
+from contextlib import nullcontext
+from datetime import datetime, timedelta
+from unittest import mock
+
+import pytest
+
+from workflow_dispatcher import TooManyRunsFoundError, NoRunsFoundError, RunTimeoutException, RunFailedException
+from workflow_dispatcher import get_recent_run, wait_for_recent_workflow_run_completion, execute_workflow_and_wait
+
+
+class FakeRun:
+    def __init__(self, created_at, status="completed", conclusion="success"):
+        self.created_at = created_at
+        self.status = status
+        self.conclusion = conclusion
+
+
+# Run execution times, spaced out by days
+RUN_EXECUTION_TIMES = [
+    datetime(2021, 1, 1, 0, 0, 0),
+    datetime(2021, 1, 2, 0, 0, 0),
+    datetime(2021, 1, 3, 0, 0, 0),
+]
+
+TIME_BEFORE_ALL_RUNS = RUN_EXECUTION_TIMES[0] - timedelta(seconds=1)
+TIME_YIELDING_LAST_RUN = RUN_EXECUTION_TIMES[-1] - timedelta(seconds=1)
+TIME_AFTER_ALL_RUNS = RUN_EXECUTION_TIMES[-1] + timedelta(seconds=1)
+
+WORKFLOW_WITHOUT_RUNS = mock.Mock()
+WORKFLOW_WITHOUT_RUNS.get_runs.return_value = []
+
+WORKFLOW_RUNS = [FakeRun(created_at=t) for t in RUN_EXECUTION_TIMES]
+
+WORKFLOW_WITH_RUNS = mock.Mock()
+WORKFLOW_WITH_RUNS.get_runs.return_value = WORKFLOW_RUNS
+
+RUN_SUCCESSFUL = FakeRun(created_at=datetime.now(), status="completed", conclusion="success")
+RUN_FAILED = FakeRun(created_at=datetime.now(), status="completed", conclusion="not successful")
+RUN_INCOMPLETE = FakeRun(
+    created_at=datetime.now(), status="not completed", conclusion="not successful"
+)
+
+
+@pytest.mark.parametrize(
+    "workflow, execution_time, expected, context_raised",
+    (
+        # successful execution yielding a single run
+        (WORKFLOW_WITH_RUNS, TIME_YIELDING_LAST_RUN, WORKFLOW_RUNS[-1], nullcontext()),
+        # unsuccessful execution due to too many runs
+        (WORKFLOW_WITH_RUNS, TIME_BEFORE_ALL_RUNS, None, pytest.raises(TooManyRunsFoundError)),
+        # unsuccessful executions due to no runs found (all filtered out)
+        (WORKFLOW_WITH_RUNS, TIME_AFTER_ALL_RUNS, None, pytest.raises(NoRunsFoundError)),
+        # unsuccessful executions due to no runs found (no runs exist)
+        (
+            WORKFLOW_WITHOUT_RUNS,
+            datetime(year=1, month=1, day=1),
+            None,
+            pytest.raises(NoRunsFoundError),
+        ),
+    ),
+)
+def test_get_recent_run(workflow, execution_time, expected, context_raised):
+    with context_raised:
+        run = get_recent_run(workflow, execution_time)
+        assert run == expected
+
+
+def test_wait_for_recent_workflow_run_completion_successful():
+    """Tests a successful case of running wait_for_recent_workflow_run_completion."""
+    workflow = "some_workflow.yaml"
+    execution_time = datetime.now()
+    timeout = 300
+    wait_between_checks = 0.1
+    expected_run = RUN_SUCCESSFUL
+    release_charms_side_effects = [NoRunsFoundError(''), expected_run]
+
+    # mock get_recent_run to return a specific run after initially raising a NoRunsFoundError
+    with mock.patch.object(
+            release_charms, "get_recent_run", side_effect=release_charms_side_effects
+    ) as mock_get_recent_run:
+        run = wait_for_recent_workflow_run_completion(
+            workflow=workflow,
+            execution_time=execution_time,
+            timeout=timeout,
+            wait_between_checks=wait_between_checks,
+        )
+
+        assert run == expected_run
+        assert mock_get_recent_run.call_count == len(release_charms_side_effects)
+        mock_get_recent_run.assert_called_with(workflow=workflow, execution_time=execution_time)
+
+
+def test_wait_for_recent_workflow_run_completion_successful():
+    """Tests a successful case of running wait_for_recent_workflow_run_completion."""
+    workflow = "some_workflow.yaml"
+    execution_time = datetime.now()
+    timeout = 2
+    wait_between_checks = 0.1
+    expected_run = RUN_SUCCESSFUL
+    release_charms_side_effects = [NoRunsFoundError(''), expected_run]
+
+    # mock get_recent_run to return a specific run after initially raising a NoRunsFoundError
+    with mock.patch.object(
+            release_charms, "get_recent_run", side_effect=release_charms_side_effects
+    ) as mock_get_recent_run:
+        run = wait_for_recent_workflow_run_completion(
+            workflow=workflow,
+            execution_time=execution_time,
+            timeout=timeout,
+            wait_between_checks=wait_between_checks,
+        )
+
+        assert run == expected_run
+        assert mock_get_recent_run.call_count == len(release_charms_side_effects)
+        mock_get_recent_run.assert_called_with(workflow=workflow, execution_time=execution_time)
+
+
+def test_wait_for_recent_workflow_run_completion_failed_no_run_found():
+    """Tests a failed execution of wait_for_recent_workflow_run_completion where no run is found.
+    """
+    workflow = "some_workflow.yaml"
+    execution_time = datetime.now()
+    timeout = 0.5
+    wait_between_checks = 0.2
+    release_charms_side_effects = [RunTimeoutException('')]
+
+    # mock get_recent_run to return a specific run after initially raising a NoRunsFoundError
+    with pytest.raises(RunTimeoutException) as raised_context:
+        with mock.patch.object(
+                release_charms, "get_recent_run", side_effect=release_charms_side_effects
+        ) as mock_get_recent_run:
+            wait_for_recent_workflow_run_completion(
+                workflow=workflow,
+                execution_time=execution_time,
+                timeout=timeout,
+                wait_between_checks=wait_between_checks,
+            )
+
+            mock_get_recent_run.assert_called_with(workflow=workflow, execution_time=execution_time)
+
+    # Assert that we did not return a run with the exception
+    assert raised_context.value.run is None
+
+
+def test_wait_for_recent_workflow_run_completion_failed_run_not_complete():
+    """Tests a failed execution where the run is not complete."""
+    workflow = "some_workflow.yaml"
+    execution_time = datetime.now()
+    timeout = 0.5
+    wait_between_checks = 0.2
+    release_charms_side_effects = [RUN_INCOMPLETE]
+
+
+    # mock get_recent_run to return a specific run after initially raising a NoRunsFoundError
+    with pytest.raises(RunTimeoutException) as raised_context:
+        with mock.patch.object(
+                release_charms, "get_recent_run", side_effect=release_charms_side_effects
+        ) as mock_get_recent_run:
+            wait_for_recent_workflow_run_completion(
+                workflow=workflow,
+                execution_time=execution_time,
+                timeout=timeout,
+                wait_between_checks=wait_between_checks,
+            )
+
+            mock_get_recent_run.assert_called_with(workflow=workflow, execution_time=execution_time)
+
+    # Assert that we did not return a run with the exception
+    assert raised_context.value.run is RUN_INCOMPLETE
+
+
+# successful run (RUN_SUCCESSFUL)
+# concluded, not successful run (RUN_FAILED) -> RunFailedException
+# not concluded -> Timeout
+@pytest.mark.parametrize(
+    "wait_for_recent_workflow_run_completion_side_effects, expected_run_returned, context_raised",
+    (
+        # successful run
+        ([RUN_SUCCESSFUL], RUN_SUCCESSFUL, nullcontext()),
+        # run concluded but not successful
+        ([RUN_FAILED], None, pytest.raises(RunFailedException)),
+        # run not concluded
+        ([RunTimeoutException()], None, pytest.raises(RunTimeoutException)),
+    )
+)
+def test_execute_workflow_and_wait(wait_for_recent_workflow_run_completion_side_effects, expected_run_returned, context_raised, mocker):
+    repository = "some/repo"
+    workflow_name = "some_workflow.yaml"
+    inputs = {}
+
+    # Mock
+
+    # mock get_workflow_from_repository to return a specific workflow
+    mock_workflow = mock.Mock()
+
+    mock_get_workflow_from_repository = mocker.patch("release_charms.get_workflow_from_repository")
+    mock_get_workflow_from_repository.return_value = mock_workflow
+
+    mock_wait_for_recent_workflow_run_completion = mocker.patch("release_charms.wait_for_recent_workflow_run_completion")
+    mock_wait_for_recent_workflow_run_completion.side_effect = wait_for_recent_workflow_run_completion_side_effects
+
+    with context_raised:
+        run = execute_workflow_and_wait(repository=repository, workflow_name=workflow_name, inputs=inputs)
+        assert run == expected_run_returned
+
+    pass
+
+
+# TODO:
+# * tests don't actually check that we update the run's data while waiting for completion

--- a/scripts/release-charms/test_workflow_dispatcher.py
+++ b/scripts/release-charms/test_workflow_dispatcher.py
@@ -9,15 +9,28 @@ from datetime import datetime, timedelta
 from unittest import mock
 
 import pytest
-
 import workflow_dispatcher
-from workflow_dispatcher import TooManyRunsFoundError, NoRunsFoundError, RunTimeoutError, RunFailedError
-from workflow_dispatcher import get_recent_run, wait_for_recent_workflow_run_completion, execute_workflow_and_wait
+from workflow_dispatcher import (
+    NoRunsFoundError,
+    RunFailedError,
+    RunTimeoutError,
+    TooManyRunsFoundError,
+    execute_workflow_and_wait,
+    get_recent_run,
+    wait_for_recent_workflow_run_completion,
+)
 
 
 class FakeRun:
     """A mock workflow Run object."""
-    def __init__(self, created_at, status="completed", conclusion="success", html_url="http://something.com/"):
+
+    def __init__(
+        self,
+        created_at,
+        status="completed",
+        conclusion="success",
+        html_url="http://something.com/",
+    ):
         self.created_at = created_at
         self.status = status
         self.conclusion = conclusion
@@ -90,11 +103,11 @@ def test_wait_for_recent_workflow_run_completion_successful():
     timeout = 2
     wait_between_checks = 0.1
     expected_run = RUN_SUCCESSFUL
-    release_charms_side_effects = [NoRunsFoundError(''), expected_run]
+    release_charms_side_effects = [NoRunsFoundError(""), expected_run]
 
     # mock get_recent_run to return a specific run after initially raising a NoRunsFoundError
     with mock.patch.object(
-            workflow_dispatcher, "get_recent_run", side_effect=release_charms_side_effects
+        workflow_dispatcher, "get_recent_run", side_effect=release_charms_side_effects
     ) as mock_get_recent_run:
         run = wait_for_recent_workflow_run_completion(
             workflow=workflow,
@@ -114,12 +127,12 @@ def test_wait_for_recent_workflow_run_completion_failed_no_run_found():
     execution_time = datetime.now()
     timeout = 0.5
     wait_between_checks = 0.2
-    release_charms_side_effects = [RunTimeoutError('')]
+    release_charms_side_effects = [RunTimeoutError("")]
 
     # mock get_recent_run to return a specific run after initially raising a NoRunsFoundError
     with pytest.raises(RunTimeoutError) as raised_context:
         with mock.patch.object(
-                workflow_dispatcher, "get_recent_run", side_effect=release_charms_side_effects
+            workflow_dispatcher, "get_recent_run", side_effect=release_charms_side_effects
         ) as mock_get_recent_run:
             wait_for_recent_workflow_run_completion(
                 workflow=workflow,
@@ -128,7 +141,9 @@ def test_wait_for_recent_workflow_run_completion_failed_no_run_found():
                 wait_between_checks=wait_between_checks,
             )
 
-            mock_get_recent_run.assert_called_with(workflow=workflow, execution_time=execution_time)
+            mock_get_recent_run.assert_called_with(
+                workflow=workflow, execution_time=execution_time
+            )
 
     # Assert that we did not return a run with the exception
     assert raised_context.value.run is None
@@ -145,7 +160,7 @@ def test_wait_for_recent_workflow_run_completion_failed_run_not_complete():
     # mock get_recent_run to return a specific run after initially raising a NoRunsFoundError
     with pytest.raises(RunTimeoutError) as raised_context:
         with mock.patch.object(
-                workflow_dispatcher, "get_recent_run", side_effect=release_charms_side_effects
+            workflow_dispatcher, "get_recent_run", side_effect=release_charms_side_effects
         ) as mock_get_recent_run:
             wait_for_recent_workflow_run_completion(
                 workflow=workflow,
@@ -154,7 +169,9 @@ def test_wait_for_recent_workflow_run_completion_failed_run_not_complete():
                 wait_between_checks=wait_between_checks,
             )
 
-            mock_get_recent_run.assert_called_with(workflow=workflow, execution_time=execution_time)
+            mock_get_recent_run.assert_called_with(
+                workflow=workflow, execution_time=execution_time
+            )
 
     # Assert that we did not return a run with the exception
     assert raised_context.value.run is RUN_INCOMPLETE
@@ -169,9 +186,14 @@ def test_wait_for_recent_workflow_run_completion_failed_run_not_complete():
         ([RUN_FAILED], None, pytest.raises(RunFailedError)),
         # run not concluded
         ([RunTimeoutError()], None, pytest.raises(RunTimeoutError)),
-    )
+    ),
 )
-def test_execute_workflow_and_wait(wait_for_recent_workflow_run_completion_side_effects, expected_run_returned, context_raised, mocker):
+def test_execute_workflow_and_wait(
+    wait_for_recent_workflow_run_completion_side_effects,
+    expected_run_returned,
+    context_raised,
+    mocker,
+):
     """Tests execute_workflow_and_wait."""
     github_token = ""
     repository = "some/repo"
@@ -181,14 +203,25 @@ def test_execute_workflow_and_wait(wait_for_recent_workflow_run_completion_side_
     # mock get_workflow_from_repository to return a specific workflow
     mock_workflow = mock.Mock()
 
-    mock_get_workflow_from_repository = mocker.patch("workflow_dispatcher.get_workflow_from_repository")
+    mock_get_workflow_from_repository = mocker.patch(
+        "workflow_dispatcher.get_workflow_from_repository"
+    )
     mock_get_workflow_from_repository.return_value = mock_workflow
 
-    mock_wait_for_recent_workflow_run_completion = mocker.patch("workflow_dispatcher.wait_for_recent_workflow_run_completion")
-    mock_wait_for_recent_workflow_run_completion.side_effect = wait_for_recent_workflow_run_completion_side_effects
+    mock_wait_for_recent_workflow_run_completion = mocker.patch(
+        "workflow_dispatcher.wait_for_recent_workflow_run_completion"
+    )
+    mock_wait_for_recent_workflow_run_completion.side_effect = (
+        wait_for_recent_workflow_run_completion_side_effects
+    )
 
     with context_raised:
-        run = execute_workflow_and_wait(github_token=github_token, repository=repository, workflow_name=workflow_name, inputs=inputs)
+        run = execute_workflow_and_wait(
+            github_token=github_token,
+            repository=repository,
+            workflow_name=workflow_name,
+            inputs=inputs,
+        )
         assert run == expected_run_returned
 
     pass

--- a/scripts/release-charms/workflow_dispatcher.py
+++ b/scripts/release-charms/workflow_dispatcher.py
@@ -222,7 +222,7 @@ def get_github_token(dry_run: bool, github_pat_environment_variable: str = "GITH
 
 def main(
         dispatch_manifest: str = typer.Argument(
-            None,  # TODO: How to make this a real required argument?  This is a hack...
+            ...,
             help="Path to the dispatch manifest YAML file.  This file is is a list of workflow "
                  "dispatch executions, each of which is a dictionary with the keys ['repository', 'workflow_name', and "
                  "'inputs'].  The 'inputs' key contains a dictionary of the inputs needed for the workflow dispatch"

--- a/scripts/release-charms/workflow_dispatcher.py
+++ b/scripts/release-charms/workflow_dispatcher.py
@@ -1,0 +1,295 @@
+import logging
+import os
+from datetime import datetime, timedelta
+from time import sleep
+from typing import Union
+import yaml
+
+import github
+from github import Github, Repository, Workflow, WorkflowRun
+import typer
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def get_workflow_from_repository(
+    github_token: str, repository: Union[str, github.Repository.Repository], workflow_name="release.yaml"
+) -> github.Workflow.Workflow:
+    """Returns a workflow object from a repository.
+
+    Note that this authenticates by
+
+    Args:
+        github_token: The github token to use for authentication.  Must have permission to
+                      trigger workflow dispatches on this repository
+        repository: The repository in which to execute the workflow, in the format "owner/repo" or
+                    a github.Repository object.
+        workflow_name: The name of the workflow to execute, typically the filename of the workflow
+
+    Returns:
+        A github.Workflow object
+    """
+    g = Github(login_or_token=github_token)
+    if not isinstance(repository, Repository.Repository):
+        repository = g.get_repo(repository)
+
+    return repository.get_workflow(workflow_name)
+
+
+def execute_workflow_and_wait(
+    github_token: str,
+    repository: Union[str, github.Repository.Repository],
+    workflow_name="release.yaml",
+    inputs: dict = None,
+):
+    """
+    Executes a workflow and waits for it to complete.
+
+    Args:
+        github_token: The github token to use for authentication.  Must have permission to trigger
+                      workflow dispatches on this repository.
+        repository: The repository in which to execute the workflow, in the format "owner/repo" or
+                    a github.Repository object.
+        workflow_name: The name of the workflow to execute, typically the filename of the workflow
+        inputs: A dictionary of inputs to pass to the workflow
+    """
+    # Name of the file in .github/workflows/ that we will execute.  This can also be the ID of the
+    # workflow, but I don't know how to get that apart from first getting the name.
+    workflow = get_workflow_from_repository(github_token, repository, workflow_name)
+
+    ref = "main"
+    # Get a timestamp immediately before we execute the workflow, in UTC, for filtering out past
+    # runs
+    execution_time = datetime.utcnow()
+    result = workflow.create_dispatch(ref=ref, inputs=inputs)
+
+    # TODO: multi-charm is using the single-charm repo workflow.  Update it!
+
+    if not result:
+        raise RunFailedException(
+            "Workflow dispatch failed.  This could be due to an incorrect input or workflow name, "
+            "or some other error.  By default, PyGithub package used to create the dispatch does "
+            "not provide any information about the failure, but you can enable their debug logging"
+            " by running with the flag --github_debug_logging."
+        )
+    logging.info(result)
+    run = wait_for_recent_workflow_run_completion(workflow=workflow, execution_time=execution_time)
+
+    if run.conclusion != "success":
+        raise RunFailedException(
+            f"Workflow {workflow_name} failed with conclusion {run.conclusion}", run=run
+        )
+    else:
+        return run
+
+
+class NoRunsFoundError(Exception):
+    pass
+
+
+class TooManyRunsFoundError(Exception):
+    def __init__(self, *args, runs=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.runs = runs
+
+
+class RunFailedException(Exception):
+    def __init__(self, *args, run: WorkflowRun.WorkflowRun, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.run = run
+
+
+class RunTimeoutException(Exception):
+    """An exception that can optionally include a github.WorkflowRun object."""
+
+    def __init__(self, *args, run: github.WorkflowRun = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.run = run
+
+
+def get_recent_run(
+    workflow: github.Workflow, execution_time: datetime
+) -> github.WorkflowRun.WorkflowRun:
+    """Returns the run that was executed after execution_time.
+
+    Raises if:
+    * NoRunsFoundError: There were no runs found since execution time
+    * TooManyRunsFoundError: there has been more than one run since execution_time.
+    """
+    runs = list(filter(lambda run: run.created_at > execution_time, workflow.get_runs()))
+    if len(runs) == 0:
+        raise NoRunsFoundError("No runs found since execution time.")
+    elif len(runs) > 1:
+        raise TooManyRunsFoundError("Found more than one run since execution_time.", runs=runs)
+    else:
+        return runs[0]
+
+
+def wait_for_recent_workflow_run_completion(
+    workflow: github.Workflow,
+    execution_time: datetime,
+    timeout: Union[int, float] = 60,
+    wait_between_checks: Union[int, float] = 1,
+) -> github.WorkflowRun:
+    """Waits for a recent workflow run to complete
+
+    This finds the most recent workflow run, waits for it to complete, and returns it.  This is
+    intended to be executed immediately after you have triggered a workflow run so that you can
+    track its progress.  This is a hack to workaround how the Github API does not return the
+    Run ID when you execute a workflow, making it difficult to execute and then track a run.
+
+    Args:
+        workflow: The workflow from which we want to wait the most recent run
+        execution_time: Timestamp immediately before the workflow run was started, in UTC.  This is
+                        used to filter out past runs.
+        timeout: The maximum amount of time to wait for the workflow to complete, in seconds
+        wait_between_checks: The amount of time to wait between checks for the workflow to complete
+
+    Exceptions:
+        RunTimeoutException: Raised if the workflow run is not found during the allowed timeout, or
+                             if it is found but not completed.  If the workflow run is found, it
+                             will be included in the `exception.run` attribute.
+
+    Returns:
+        The workflow run that was executed after execution_time.
+    """
+    reference_time = datetime.now()
+    timeout = timedelta(seconds=timeout)
+
+    def elapsed_time():
+        """Returns the elapsed time since reference_time"""
+        return datetime.now() - reference_time
+
+    run = None
+    logger.info(f"Looking for run of workflow '{workflow.name}' at url {workflow.url}")
+    while elapsed_time() < timeout:
+        # If we haven't found the run yet, look for it.  Else, keep using the same one
+        if run is None:
+            try:
+                run = get_recent_run(workflow=workflow, execution_time=execution_time)
+                logger.info(f"Found workflow run with url: {run.html_url}")
+            except NoRunsFoundError as err:
+                logger.info(
+                    f"No runs found yet.  Sleeping {wait_between_checks} seconds and retrying."
+                )
+                sleep(wait_between_checks)
+                continue
+            except TooManyRunsFoundError as err:
+                logger.error(
+                    f"Found more than one run since execution_time {execution_time}: got runs {err.runs}"
+                )
+        else:
+            logger.info(f"Updating workflow run's data")
+            run.update()
+
+        # Return run if complete
+        logger.info(f"Checking run status for completion.  Current status is {run.status}")
+        if run.status == "completed":
+            return run
+            # if run.conclusion == "success":
+            #     print("Workflow completed successfully")
+            #     return run
+            # else:
+            #     # No obvious way to get the inputs from the run, so cannot say "executed on repo X with
+            #     # inputs Y" here
+            #     raise RunFailedException(f"Workflow failed with conclusion {run.conclusion} (html_url={run.html_url})")
+
+        sleep(wait_between_checks)
+
+    if run is None:
+        msg = f"Timed out without finding a recent run for workflow"
+        logger.error(msg)
+        raise RunTimeoutException(msg)
+    else:
+        msg = f"Timed out waiting for workflow to complete"
+        logger.error(msg)
+        raise RunTimeoutException(msg, run=run)
+
+
+def get_github_token(dry_run: bool, github_pat_environment_variable: str = "GITHUB_PAT"):
+    if dry_run:
+        github_token = None
+    else:
+        github_token = os.environ.get(github_pat_environment_variable, None)
+        if not github_token:
+            raise ValueError(f"Environment variable {github_pat_environment_variable} is not set.  "
+                             f"This must be set to a Github Personal Access Token that can trigger"
+                             f"workflow dispatches.")
+    return github_token
+
+
+def main(
+        dispatch_manifest: str = typer.Argument(
+            None,  # TODO: How to make this a real required argument?  This is a hack...
+            help="Path to the dispatch manifest YAML file.  This file is is a list of workflow "
+                 "dispatch executions, each of which is a dictionary with the keys ['repository', 'workflow_name', and "
+                 "'inputs'].  The 'inputs' key contains a dictionary of the inputs needed for the workflow dispatch"
+        ),
+        dry_run: bool = typer.Option(
+            default=True,
+            help="If true, do not actually execute the workflow.  This is useful for seeing what "
+                 "will happen before actually doing something irreversible",
+        ),
+        github_debug_logging: bool = typer.Option(
+            default=False,
+            help="If true, enable debug logging for the PyGithub package.  This is useful for "
+                 "debugging failures, but is very verbose and not recommended for normal use."
+        ),
+        github_pat_environment_variable: str = typer.Option(
+            default="GITHUB_PAT",
+            help="The name of the environment variable that contains the Github Personal Access"
+                 "Token to use for authentication.  This token required for all execution except"
+                 "dry runs."
+        )
+):
+    """
+    Triggers one or more Github workflow dispatch runs
+
+    This script triggers one or more Github repository workflow dispatches, as defined in a YAML
+    dispatch_manifest file.  The execution uses the Github token found in the environment variable
+    named by the github_pat_environment_variable argument.
+
+    The dispatch_manifest is a YAML list of dictionaries, like
+    (you can ignore the extra newlines... without them, the help text outputs even worse :/ ):
+
+        - repository: "some-owner/some-repo"\n
+          workflow_name: "some_workflow_file.yaml"\n
+          inputs:\n
+            workflow-input-1: "abc"\n
+            workflow-input-2: "xyz"\n
+        - repository: "some-other-other/some-other-repo"\n
+          workflow_name: "some_other_workflow_file.yaml"\n
+          inputs:\n
+            another-input: "123"\n
+
+    Each dispatch is executed in series and waited on until it completes.
+    """
+    if github_debug_logging:
+        github.enable_console_debug_logging()
+
+    github_token = get_github_token(dry_run=dry_run, github_pat_environment_variable=github_pat_environment_variable)
+
+    with open(dispatch_manifest) as f:
+        workflows_to_execute = yaml.safe_load(f)
+
+    for workflow in workflows_to_execute:
+        if dry_run:
+            logger.info(
+                f"Dry run: would execute workflow {workflow['workflow_name']} in repository {workflow['repository']} with inputs {workflow['inputs']}"
+            )
+        else:
+            try:
+                execute_workflow_and_wait(
+                    github_token=github_token,
+                    repository=workflow["repository"],
+                    workflow_name=workflow["workflow_name"],
+                    inputs=workflow["inputs"],
+                )
+            except RunTimeoutException as e:
+                logger.info(f"Workflow run for {workflow['workflow_name']} in repository {workflow['repository']} timed out with message: {e.message}")
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/scripts/release-charms/workflow_dispatcher.py
+++ b/scripts/release-charms/workflow_dispatcher.py
@@ -75,13 +75,13 @@ def execute_workflow_and_wait(
 
     if not result:
         raise RunFailedError(
-            "Workflow dispatch failed.  This could be due to an incorrect input or workflow name, "
-            "or some other error.  By default, PyGithub package used to create the dispatch does "
-            "not provide any information about the failure, but you can enable their debug logging"
-            " by running with the flag --github_debug_logging."
+            "Workflow dispatch failed.  This could be due to an incorrect input or workflow name,"
+            " or some other error.  By default, PyGithub package used to create the dispatch does"
+            " not provide any information about the failure, but you can enable their debug "
+            "logging by running with the flag --github_debug_logging."
         )
     logging.info(result)
-    run = wait_for_recent_workflow_run_completion(workflow=workflow, execution_time=execution_time)
+    run = wait_for_recent_workflow_run_completion(workflow, execution_time)
 
     if run.conclusion != "success":
         raise RunFailedError(
@@ -163,15 +163,16 @@ def wait_for_recent_workflow_run_completion(
 
     Args:
         workflow: The workflow from which we want to wait the most recent run
-        execution_time: Timestamp immediately before the workflow run was started, in UTC.  This is
+        execution_time: Timestamp immediately before the workflow run was started, in UTC. This is
                         used to filter out past runs.
         timeout: The maximum amount of time to wait for the workflow to complete, in seconds
-        wait_between_checks: The amount of time to wait between checks for the workflow to complete
+        wait_between_checks: The amount of time to wait between checks for the workflow to
+                             complete
 
     Exceptions:
-        RunTimeoutException: Raised if the workflow run is not found during the allowed timeout, or
-                             if it is found but not completed.  If the workflow run is found, it
-                             will be included in the `exception.run` attribute.
+        RunTimeoutException: Raised if the workflow run is not found during the allowed timeout,
+                             or if it is found but not completed.  If the workflow run is found,
+                             it will be included in the `exception.run` attribute.
 
     Returns:
         The workflow run that was executed after execution_time.
@@ -199,7 +200,8 @@ def wait_for_recent_workflow_run_completion(
                 continue
             except TooManyRunsFoundError as err:
                 logger.error(
-                    f"Found more than one run since execution_time {execution_time}: got runs {err.runs}"
+                    f"Found more than one run since execution_time {execution_time}: got runs "
+                    f"{err.runs}"
                 )
         else:
             logger.info("Updating workflow run's data")
@@ -241,8 +243,9 @@ def main(
     dispatch_manifest: str = typer.Argument(
         ...,
         help="Path to the dispatch manifest YAML file.  This file is is a list of workflow "
-        "dispatch executions, each of which is a dictionary with the keys ['repository', 'workflow_name', and "
-        "'inputs'].  The 'inputs' key contains a dictionary of the inputs needed for the workflow dispatch",
+        "dispatch executions, each of which is a dictionary with the keys ['repository', "
+        "'workflow_name', and 'inputs'].  The 'inputs' key contains a dictionary of the "
+        "inputs needed for the workflow dispatch",
     ),
     dry_run: bool = typer.Option(
         default=True,
@@ -295,7 +298,8 @@ def main(
     for workflow in workflows_to_execute:
         if dry_run:
             logger.info(
-                f"Dry run: would execute workflow {workflow['workflow_name']} in repository {workflow['repository']} with inputs {workflow['inputs']}"
+                f"Dry run: would execute workflow {workflow['workflow_name']} in repository "
+                f"{workflow['repository']} with inputs {workflow['inputs']}"
             )
         else:
             try:
@@ -307,7 +311,8 @@ def main(
                 )
             except RunTimeoutError as e:
                 logger.info(
-                    f"Workflow run for {workflow['workflow_name']} in repository {workflow['repository']} timed out with message: {e.message}"
+                    f"Workflow run for {workflow['workflow_name']} in repository "
+                    f"{workflow['repository']} timed out with message: {e.message}"
                 )
 
 

--- a/scripts/release-charms/workflow_dispatcher.py
+++ b/scripts/release-charms/workflow_dispatcher.py
@@ -9,19 +9,20 @@ import os
 from datetime import datetime, timedelta
 from time import sleep
 from typing import Union
-import yaml
 
 import github
-from github import Github, Repository, Workflow, WorkflowRun  # noqa: F401  # Workflow is used
 import typer
-
+import yaml
+from github import Github, Repository, Workflow, WorkflowRun  # noqa: F401  # Workflow is used
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
 def get_workflow_from_repository(
-    github_token: str, repository: Union[str, github.Repository.Repository], workflow_name="release.yaml"
+    github_token: str,
+    repository: Union[str, github.Repository.Repository],
+    workflow_name="release.yaml",
 ) -> github.Workflow.Workflow:
     """Returns a workflow object from a repository.
 
@@ -92,6 +93,7 @@ def execute_workflow_and_wait(
 
 class NoRunsFoundError(Exception):
     """Raised if no runs are found for a workflow."""
+
     pass
 
 
@@ -100,6 +102,7 @@ class TooManyRunsFoundError(Exception):
 
     This exception can optionally include a list of github.WorkflowRun objects.
     """
+
     def __init__(self, *args, runs=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.runs = runs
@@ -110,6 +113,7 @@ class RunFailedError(Exception):
 
     This exception can optionally include a github.WorkflowRun object.
     """
+
     def __init__(self, *args, run: WorkflowRun.WorkflowRun, **kwargs):
         super().__init__(*args, **kwargs)
         self.run = run
@@ -120,6 +124,7 @@ class RunTimeoutError(Exception):
 
     This exception can optionally include a github.WorkflowRun object.
     """
+
     def __init__(self, *args, run: github.WorkflowRun = None, **kwargs):
         super().__init__(*args, **kwargs)
         self.run = run
@@ -224,35 +229,37 @@ def get_github_token(dry_run: bool, github_pat_environment_variable: str = "GITH
     else:
         github_token = os.environ.get(github_pat_environment_variable, None)
         if not github_token:
-            raise ValueError(f"Environment variable {github_pat_environment_variable} is not set.  "
-                             f"This must be set to a Github Personal Access Token that can trigger"
-                             f"workflow dispatches.")
+            raise ValueError(
+                f"Environment variable {github_pat_environment_variable} is not set.  "
+                f"This must be set to a Github Personal Access Token that can trigger"
+                f"workflow dispatches."
+            )
     return github_token
 
 
 def main(
-        dispatch_manifest: str = typer.Argument(
-            ...,
-            help="Path to the dispatch manifest YAML file.  This file is is a list of workflow "
-                 "dispatch executions, each of which is a dictionary with the keys ['repository', 'workflow_name', and "
-                 "'inputs'].  The 'inputs' key contains a dictionary of the inputs needed for the workflow dispatch"
-        ),
-        dry_run: bool = typer.Option(
-            default=True,
-            help="If true, do not actually execute the workflow.  This is useful for seeing what "
-                 "will happen before actually doing something irreversible",
-        ),
-        github_debug_logging: bool = typer.Option(
-            default=False,
-            help="If true, enable debug logging for the PyGithub package.  This is useful for "
-                 "debugging failures, but is very verbose and not recommended for normal use."
-        ),
-        github_pat_environment_variable: str = typer.Option(
-            default="GITHUB_PAT",
-            help="The name of the environment variable that contains the Github Personal Access"
-                 "Token to use for authentication.  This token required for all execution except"
-                 "dry runs."
-        )
+    dispatch_manifest: str = typer.Argument(
+        ...,
+        help="Path to the dispatch manifest YAML file.  This file is is a list of workflow "
+        "dispatch executions, each of which is a dictionary with the keys ['repository', 'workflow_name', and "
+        "'inputs'].  The 'inputs' key contains a dictionary of the inputs needed for the workflow dispatch",
+    ),
+    dry_run: bool = typer.Option(
+        default=True,
+        help="If true, do not actually execute the workflow.  This is useful for seeing what "
+        "will happen before actually doing something irreversible",
+    ),
+    github_debug_logging: bool = typer.Option(
+        default=False,
+        help="If true, enable debug logging for the PyGithub package.  This is useful for "
+        "debugging failures, but is very verbose and not recommended for normal use.",
+    ),
+    github_pat_environment_variable: str = typer.Option(
+        default="GITHUB_PAT",
+        help="The name of the environment variable that contains the Github Personal Access"
+        "Token to use for authentication.  This token required for all execution except"
+        "dry runs.",
+    ),
 ):
     r"""Triggers one or more Github workflow dispatch runs
 
@@ -278,7 +285,9 @@ def main(
     if github_debug_logging:
         github.enable_console_debug_logging()
 
-    github_token = get_github_token(dry_run=dry_run, github_pat_environment_variable=github_pat_environment_variable)
+    github_token = get_github_token(
+        dry_run=dry_run, github_pat_environment_variable=github_pat_environment_variable
+    )
 
     with open(dispatch_manifest) as f:
         workflows_to_execute = yaml.safe_load(f)
@@ -297,7 +306,9 @@ def main(
                     inputs=workflow["inputs"],
                 )
             except RunTimeoutError as e:
-                logger.info(f"Workflow run for {workflow['workflow_name']} in repository {workflow['repository']} timed out with message: {e.message}")
+                logger.info(
+                    f"Workflow run for {workflow['workflow_name']} in repository {workflow['repository']} timed out with message: {e.message}"
+                )
 
 
 if __name__ == "__main__":

--- a/tox.ini
+++ b/tox.ini
@@ -60,12 +60,21 @@ commands = python3 ./scripts/branch_creation.py {posargs}
 
 [testenv:test_branch_creation]
 description = Test branch creation
-deps = 
-  pyyaml
-  requests
-  GitPython
-  pytest
-  requests-mock
-  pytest-mock
-commands = 
-  pytest -v --tb native {[vars]scripts_test_path}/test_branch_creation.py --log-cli-level=INFO -s {posargs}
+deps =
+    pyyaml
+    requests
+    GitPython
+    pytest
+    requests-mock
+    pytest-mock
+commands =
+    pytest -v --tb native {[vars]scripts_test_path}/test_branch_creation.py --log-cli-level=INFO -s {posargs}
+
+[testenv:test_batch_release_charms]
+description = Test tools for batch-releasing multiple charms
+deps =
+    pytest
+    pytest-mock
+    -r ./scripts/release-charms/requirements.txt
+commands =
+    pytest -v --tb native {[vars]scripts_path}/release-charms/. --log-cli-level=INFO -s {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ deps =
     codespell
 commands =
     codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
-      --skip {toxinidir}/cannon_runs --skip {toxinidir}/venv
+      --skip {toxinidir}/cannon_runs --skip **/venv
     # pflake8 wrapper supports config from pyproject.toml
     pflake8 {[vars]scripts_path}
     isort --check-only --diff {[vars]scripts_path}

--- a/tox.ini
+++ b/tox.ini
@@ -75,6 +75,6 @@ description = Test tools for batch-releasing multiple charms
 deps =
     pytest
     pytest-mock
-    -r ./scripts/release-charms/requirements.txt
+    -r{toxinidir}/scripts/release-charms/requirements.txt
 commands =
     pytest -v --tb native {[vars]scripts_path}/release-charms/. --log-cli-level=INFO -s {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8<4.1
+    flake8
     flake8-docstrings
     flake8-copyright
     flake8-builtins


### PR DESCRIPTION
Adds workflow_dispatcher.py and create_release_workflow_dispatch_manifest.py which together make it easier to release multiple charms from one channel to another at once.  See the included README.md for usage instructions

NOTE:
* this PR depends on additional features [added to chisme](https://github.com/canonical/charmed-kubeflow-chisme/pull/27).  At the moment, you must have them locally and edit the requirements.txt file to reference your local copy

Test instructions:
* get a local version of the above chisme PR and add to your requirements.txt file, as mentioned above
* use `tox -e test_batch_release_charms`

Todo before merging:
* [x] [this chisme PR](https://github.com/canonical/charmed-kubeflow-chisme/pull/27) must be merged and released
* [x] requirements.txt in this current PR must be updated to use chisme from pypi
* [ ] squash the debugging commits out of this (or squash merge)