### PR TITLE
[JUJU-1843] Set kfp requirement for 1dot6 to <2

### DIFF
--- a/tests/1dot6/requirements.txt
+++ b/tests/1dot6/requirements.txt
@@ -1,4 +1,4 @@
 lightkube
 pytest
 pytest-operator
-kfp>=2.0.0
+kfp<2.0.0


### PR DESCRIPTION
It's previous setting >=2 does not match any released version of kfp, causing the tests to fail.

NOTE: At the moment this library isn't being used by the 1dot6 ci. Don't remove it since it very likely will be in the future