### PR TITLE
[JUJU-1843] Add KUBECONFIG to passenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ passenv =
   PYTHONPATH
   CHARM_BUILD_DIR
   MODEL_SETTINGS
+  KUBECONFIG
 
 [testenv:fmt]
 description = Apply coding style standards to code


### PR DESCRIPTION
This will allow users to pass in a custom kubeconfig to Lightkube via this envvar, instead of always using ~/.kube/config