### PR TITLE
add batch run fixing renovate.json files

### DIFF
--- a/cannon_runs/2022-12-14_fix-renovate-pip-compile-fileMatch/README.md
+++ b/cannon_runs/2022-12-14_fix-renovate-pip-compile-fileMatch/README.md
@@ -1,0 +1,13 @@
+# Summary
+
+This batch operation fixes the fileMatch patterns used by Renovate for pip-compile, as described in [this argo-operators PR](https://github.com/canonical/argo-operators/pull/71).
+
+# Execution details
+
+This is a batch update to our repos completed using [git-xargs](https://github.com/gruntwork-io/git-xargs).  Execution was completed using commands listed in `run_git-xargs.sh`.
+
+`git-xargs` executes the script you provide to modify one or more repos.  It:
+* pulls each repo
+* executes the provided script in the root dir of each repo
+* creates PRs for each change
+* tries to handle rate limiting issues from GitHub

--- a/cannon_runs/2022-12-14_fix-renovate-pip-compile-fileMatch/main.sh
+++ b/cannon_runs/2022-12-14_fix-renovate-pip-compile-fileMatch/main.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -x
+
+# This script:
+# * finds and bumps all uses of github actions from `canonical/charming-actions` to v2.1.1.  
+
+echo "Script is executing from $(pwd)"
+
+FILEMATCH='["(^|/)requirements\\.in$", "(^|/)requirements-fmt\\.in$", "(^|/)requirements-lint\\.in$", "(^|/)requirements-unit\\.in$", "(^|/)requirements-integration\\.in$", "(^|/)requirements.*\\.in$"]'
+
+cat renovate.json |  jq --indent 4 --argjson filematch "$FILEMATCH" '."pip-compile".fileMatch |= $filematch' > renovate.json.tmp && mv renovate.json.tmp renovate.json

--- a/cannon_runs/2022-12-14_fix-renovate-pip-compile-fileMatch/repos.txt
+++ b/cannon_runs/2022-12-14_fix-renovate-pip-compile-fileMatch/repos.txt
@@ -1,0 +1,30 @@
+# Generated using `gh search repos --topic charmed-kubeflow | awk '{print $1}' > repos.txt`
+# Note that this list was all charms as of this run, but if running this in future you should build
+# your own list as new repositories may have been added.  
+# This execution used the entire list, but if you know you only need to search a subset of the
+# repos you could filter this list first. 
+canonical/bundle-kubeflow
+canonical/argo-operators
+canonical/istio-operators
+canonical/seldon-core-operator
+canonical/notebook-operators
+canonical/training-operator
+canonical/kubeflow-ci
+canonical/envoy-operator
+canonical/kserve-operators
+canonical/minio-operator
+canonical/kfp-operators
+canonical/kubeflow-profiles-operator
+canonical/knative-operators
+canonical/charmed-kubeflow-chisme
+canonical/admission-webhook-operator
+canonical/kubeflow-roles-operator
+canonical/kubeflow-dashboard-operator
+canonical/metacontroller-operator
+canonical/mlmd-operator
+canonical/kubeflow-tensorboards-operator
+canonical/argo-operators
+canonical/katib-operators
+canonical/oidc-gatekeeper-operator
+canonical/kubeflow-volumes-operator
+canonical/dex-auth-operator

--- a/cannon_runs/2022-12-14_fix-renovate-pip-compile-fileMatch/run_git-xargs.sh
+++ b/cannon_runs/2022-12-14_fix-renovate-pip-compile-fileMatch/run_git-xargs.sh
@@ -1,0 +1,26 @@
+# Settings - edit these to your case if you're reusing this file
+PULL_REQUEST_TITLE="fix: pip-compile fileMatch pattern in renovate.json"
+BRANCH_NAME="fix-renovate-pip-compile-fileMatch"
+COMMIT_MESSAGE="Fixes the fileMatch pattern used by the Renovate bot for pip-compile files.  See [this argo-operators PR](https://github.com/canonical/argo-operators/pull/71) for a full description of the fix."  # Also used as the PR description
+NO_SKIP_CI="--no-skip-ci"  # If the PRs opened should trigger tests, leave this in.  Else, comment this out
+# OTHER_ARGS="--loglevel DEBUG --dry-run --draft"  # Useful during testing.  Comment it out during real runs
+
+# Main (you probably don't need to change things below here)
+
+# Get the absolute path to where this script lives, so we can copy files
+# from here without knowing that path ahead of runtime.
+# Taken from https://stackoverflow.com/a/4774063/5394584
+# Seems like there's cases where this might not work, but generally good?
+SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+# Execute
+# during testing, use:
+#   --loglevel DEBUG --dry-run --draft\
+# NOTE: The script path passed as the positional arg below must be absolute, not relative
+git-xargs \
+  --repos repos.txt \
+  --branch-name "$BRANCH_NAME" \
+  --pull-request-title "$PULL_REQUEST_TITLE" \
+  --commit-message "$COMMIT_MESSAGE" \
+  $NO_SKIP_CI $OTHER_ARGS \
+  bash $SCRIPTPATH/main.sh


### PR DESCRIPTION
This PR archives the files used to do a batch edit of our charms with git-xargs, specifically to update the renovate.json files to fix a fileMatch typo (see [this pr](https://github.com/canonical/argo-operators/pull/71) for more details)
