### PR TITLE
fix: updated script call to ensure proper execution

### DIFF
--- a/scripts/images/get-all-images.sh
+++ b/scripts/images/get-all-images.sh
@@ -6,7 +6,9 @@ REPOS=($(grep _github_repo_name $BUNDLE_FILE | awk '{print $2}' | sort --unique)
 for REPO in "${REPOS[@]}"; do
   git clone https://github.com/canonical/$REPO
   cd $REPO
-  IMAGES+=($($REPO/tools/get-images-$RELEASE.sh))
-  cd -
+  if test -f "./tools/get-images-$RELEASE.sh"; then
+    IMAGES+=($(./tools/get-images-$RELEASE.sh))
+  fi
+  cd - > /dev/null
 done
 printf "%s\n" "${IMAGES[@]}"


### PR DESCRIPTION
Script was called with $REPO prepended. After re-design this should have been removed.

Summary of changes:
- Removed not needed $REPO fron script call.