### PR TITLE
fix: added two new repositories to sync

### DIFF
--- a/.github/workflows/sync_charmstore_credentials.yaml
+++ b/.github/workflows/sync_charmstore_credentials.yaml
@@ -24,7 +24,9 @@ jobs:
             ^canonical/dex-auth-operator$
             ^canonical/envoy-operator$
             ^canonical/istio-operators$
+            ^canonical/katib-operators$
             ^canonical/kfp-operators$
+            ^canonical/knative-operators$
             ^canonical/kserve-operators$
             ^canonical/kubeflow-dashboard-operator$
             ^canonical/kubeflow-profiles-operator$


### PR DESCRIPTION
This PR should have been done when new repositories were added to CKF.

Summary of changes:
- Added two new repositories to sync workflow. It is required to propagate charmcraft credentials to new repositories.