### PR TITLE
Update workflows.md with longer ttl

### DIFF
--- a/.github/workflows/workflows.md
+++ b/.github/workflows/workflows.md
@@ -15,7 +15,7 @@ charm login && cat ~/.go-cookies
 ```
 (charmcraft (requires charmcraft > 1.3.1)
 ```
-charmcraft login --export /tmp/charmcraft.credentials && echo "Copy the key below this line" && cat /tmp/charmcraft.credentials && rm /tmp/charmcraft.credentials
+charmcraft login --export --ttl 15000000 /tmp/charmcraft.credentials && echo "Copy the key below this line" && cat /tmp/charmcraft.credentials && rm /tmp/charmcraft.credentials
 ```
 
 2. Insert above credentials into this repo's CHARMSTORE_CREDENTIAL/CHARMCRAFT_CREDENTIALS secret (Settings->Secrets)


### PR DESCRIPTION
Previously, the charmcraft credential sync instructions suggested using the default `charmcraft login` ttl, which is about 30 hours.  This updates it to ~6 months.