### PR TITLE
fix: Collect Charmcraft logs as part of CI action

### DIFF
--- a/actions/dump-charm-debug-artifacts/logdump.bash
+++ b/actions/dump-charm-debug-artifacts/logdump.bash
@@ -55,12 +55,10 @@ echo "Dumping logs to ${OUTPUT_DIR}"
 shopt -s nullglob
 # Common for most installs
 for f in $HOME/snap/charmcraft/common/cache/charmcraft/log/charmcraft-*.log; do
-    echo cat $f | tee $OUTPUT_DIR/`basename $f`
     cat $f | tee "$OUTPUT_DIR/`basename $f`"
 done
 # A spot sometimes seen on a gh runner
 for f in $HOME/.local/state/charmcraft/log/charmcraft-*.log; do
-    echo cat $f | tee $OUTPUT_DIR/`basename $f`
     cat $f | tee "$OUTPUT_DIR/`basename $f`"
 done
 shopt -u nullglob

--- a/actions/dump-charm-debug-artifacts/logdump.bash
+++ b/actions/dump-charm-debug-artifacts/logdump.bash
@@ -52,6 +52,7 @@ echo "Dumping logs to ${OUTPUT_DIR}"
 # Charmcraft
 
 # Collect charmcraft log files from typical locations, if they exist
+shopt -s nullglob
 # Common for most installs
 for f in $HOME/snap/charmcraft/common/cache/charmcraft/log/charmcraft-*.log; do
     echo cat $f | tee $OUTPUT_DIR/`basename $f`
@@ -62,6 +63,7 @@ for f in $HOME/.local/state/charmcraft/log/charmcraft-*.log; do
     echo cat $f | tee $OUTPUT_DIR/`basename $f`
     cat $f | tee "$OUTPUT_DIR/`basename $f`"
 done
+shopt -u nullglob
 
 
 ############

--- a/actions/dump-charm-debug-artifacts/logdump.bash
+++ b/actions/dump-charm-debug-artifacts/logdump.bash
@@ -53,12 +53,12 @@ echo "Dumping logs to ${OUTPUT_DIR}"
 
 # Collect charmcraft log files from typical locations, if they exist
 # Common for most installs
-for f in `ls "$HOME/snap/charmcraft/common/cache/charmcraft/log/charmcraft-*.log"`; do
+for f in $HOME/snap/charmcraft/common/cache/charmcraft/log/charmcraft-*.log; do
     echo cat $f | tee $OUTPUT_DIR/`basename $f`
     cat $f | tee "$OUTPUT_DIR/`basename $f`"
 done
 # A spot sometimes seen on a gh runner
-for f in `ls "$HOME/.local/state/charmcraft/log/charmcraft-*.log"`; do
+for f in $HOME/.local/state/charmcraft/log/charmcraft-*.log; do
     echo cat $f | tee $OUTPUT_DIR/`basename $f`
     cat $f | tee "$OUTPUT_DIR/`basename $f`"
 done


### PR DESCRIPTION
Fix `logdump` issue that prevents Charmcraft logs from being collected as part of the relevant CI action. This was due to the provided path not being extended as desired in the `logdump` bash script. More details in the linked issue.

Closes #92