### PR TITLE
fix: save space

### DIFF
--- a/scripts/images/get-all-images.sh
+++ b/scripts/images/get-all-images.sh
@@ -8,7 +8,6 @@ BUNDLE_FILE=$1
 IMAGES=()
 # retrieve all repositories and branches for CKF
 REPOS_BRANCHES=($(yq -r '.applications[] | to_json' $BUNDLE_FILE | jq -r 'select(._github_repo_name) | "\(._github_repo_name):\(._github_repo_branch)"' | sort --unique))
-print "CKF repos:"
 printf "%s\n" "${REPOS_BRANCHES[@]}"
 
 for REPO_BRANCH in "${REPOS_BRANCHES[@]}"; do
@@ -17,11 +16,11 @@ for REPO_BRANCH in "${REPOS_BRANCHES[@]}"; do
   cd $REPO
   IMAGES+=($(bash ./tools/get-images.sh))
   cd - > /dev/null
+  rm -rf $REPO
 done
 
 # retrieve all repositories and branches for dependencies
 DEP_REPOS_BRANCHES=($(yq -r '.applications[] | to_json' $BUNDLE_FILE | jq -r 'select(._github_dependency_repo_name) | "\(._github_dependency_repo_name):\(._github_dependency_repo_branch)"' | sort --unique))
-print "Dependency repos:"
 printf "%s\n" "${DEP_REPOS_BRANCHES[@]}"
 
 for REPO_BRANCH in "${DEP_REPOS_BRANCHES[@]}"; do
@@ -31,6 +30,7 @@ for REPO_BRANCH in "${DEP_REPOS_BRANCHES[@]}"; do
   # for dependencies only retrieve workload containers from metadata.yaml
   IMAGES+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
   cd - > /dev/null
+  rm -rf $REPO
 done
 
 printf "%s\n" "${IMAGES[@]}"


### PR DESCRIPTION
GH runners are running out of space. Need to add cleanup of interemediate, not needed artefacts.

Summary of changes:
- Added removal of repositories to save space.
- Removed not needed debug logs.