### PR TITLE
Feat summary per class script

### DIFF
--- a/scripts/images/get-summary.py
+++ b/scripts/images/get-summary.py
@@ -1,0 +1,87 @@
+#!/usr/bin/python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+
+"""Script to process Trivy vulnerability scans reports and produce summary."""
+
+import argparse
+import json
+from pathlib import Path
+
+
+def parse_json(filename):
+    """Parse JSON file"""
+    record_list = []
+    with open(filename, "r") as json_file:
+        data = json.load(json_file)
+
+    artifact = data["ArtifactName"]
+    if "OS" in data["Metadata"]:
+        base = f"{data['Metadata']['OS']['Family']}:{data['Metadata']['OS']['Name']}"
+    else:
+        base = "N/A"
+
+    if "Results" not in data:
+        # no scan results found, skip this report
+        print(f"No results in report {filename}")
+        return []
+
+    for result in data["Results"]:
+        if "Vulnerabilities" not in result or len(result["Vulnerabilities"]) == 0:
+            # no vulnerabilities found, skip this report
+            continue
+        package_type = result["Class"]
+        vuln_list = result["Vulnerabilities"]
+        for vuln in vuln_list:
+            record_list.append(
+                {
+                    "artifact": artifact,
+                    "base": base,
+                    "class": package_type,
+                    "severity": vuln["Severity"],
+                }
+            )
+
+    return record_list
+
+
+def main(report_path):
+    input_path = Path(report_path)
+
+    file_list = []
+    if input_path.is_dir():
+        # directory is supplied, retrieve list of files
+        file_list = list(input_path.iterdir())
+    elif input_path.is_file():
+        file_list.append(input_path)
+    else:
+        print(f"Invalid input {report_path} supplied")
+        return
+
+    if not file_list:
+        print(f"Failed to retrieve list of files from {report_path}")
+        return
+
+    for file in file_list:
+        if file.suffix == ".json":
+            records = parse_json(file)
+        else:
+            continue
+
+        # create and output summary
+        lang_pkgs = {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0, "UNKNOWN": 0}
+        os_pkgs = {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0, "UNKNOWN": 0}
+        for record in records:
+            if record["class"] == "os-pkgs":
+                os_pkgs[record["severity"]] = os_pkgs[record["severity"]] + 1
+            if record["class"] == "lang-pkgs":
+                lang_pkgs[record["severity"]] = lang_pkgs[record["severity"]] + 1
+
+        print(f"{record['artifact']},{record['base']},{os_pkgs['CRITICAL']},{os_pkgs['HIGH']},{os_pkgs['MEDIUM']},{os_pkgs['LOW']},{lang_pkgs['CRITICAL']},{lang_pkgs['HIGH']},{lang_pkgs['MEDIUM']},{lang_pkgs['LOW']}")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--report-path")
+    args = parser.parse_args()
+    main(args.report_path)

--- a/scripts/images/get-summary.py
+++ b/scripts/images/get-summary.py
@@ -39,23 +39,25 @@ def get_base_os(report_json: dict) -> str:
     """Return the OS base name by parsing the trivy report data."""
     base = "N/A"
     if "OS" in report_json["Metadata"]:
-        base = "%s:%s" % (report_json['Metadata']['OS']['Family'],
-                          report_json['Metadata']['OS']['Name'])
+        base = "%s:%s" % (
+            report_json["Metadata"]["OS"]["Family"],
+            report_json["Metadata"]["OS"]["Name"],
+        )
 
     return base
 
 
 def get_oci_image_name(report_json: dict) -> str:
     """Return the name of the OCI Image from the trivy report data."""
-    OCI_IMAGE_KEY = "ArtifactName"
-    if OCI_IMAGE_KEY not in report_json:
+    oci_image_key = "ArtifactName"
+    if oci_image_key not in report_json:
         raise ValueError("No 'ArtifactName' key was found on the report")
 
-    return report_json[OCI_IMAGE_KEY]
+    return report_json[oci_image_key]
 
 
 def flatten_vulnerabilities(report_json) -> List[dict]:
-    """Return a list of vulnerabilites that contain severity and class."""
+    """Return a list of vulnerabilities that contain severity and class."""
     if "Results" not in report_json:
         # no scan results found, skip this report
         return []
@@ -68,8 +70,7 @@ def flatten_vulnerabilities(report_json) -> List[dict]:
 
         # class is either os-pkgs or lang-pkgs
         for vuln in result["Vulnerabilities"]:
-            vuln_list.append({"class": result["Class"],
-                              "severity": vuln["Severity"]})
+            vuln_list.append({"class": result["Class"], "severity": vuln["Severity"]})
 
     return vuln_list
 
@@ -77,11 +78,24 @@ def flatten_vulnerabilities(report_json) -> List[dict]:
 def main(report_path, print_header):
     file_list = get_reports_files_list(report_path)
 
-    HEADER_ROW = ["IMAGE", "BASE", "CRITICAL", "HIGH", "MEDIUM", "LOW",
-                  "CRITICAL-OS", "CRITICAL-LANG", "HIGH-OS", "HIGH-LANG",
-                  "MEDIUM-OS", "MEDIUM-LANG", "LOW-OS", "LOW-LANG"]
+    header_roq = [
+        "IMAGE",
+        "BASE",
+        "CRITICAL",
+        "HIGH",
+        "MEDIUM",
+        "LOW",
+        "CRITICAL-OS",
+        "CRITICAL-LANG",
+        "HIGH-OS",
+        "HIGH-LANG",
+        "MEDIUM-OS",
+        "MEDIUM-LANG",
+        "LOW-OS",
+        "LOW-LANG",
+    ]
     if print_header:
-        print(",".join(HEADER_ROW))
+        print(",".join(header_roq))
 
     for file in file_list:
         if file.suffix != ".json":
@@ -94,12 +108,9 @@ def main(report_path, print_header):
         base_os = get_base_os(report_json)
 
         # calculate total number of CVEs per category
-        lang_pkgs = {"CRITICAL": 0, "HIGH": 0,
-                     "MEDIUM": 0, "LOW": 0, "UNKNOWN": 0}
-        os_pkgs = {"CRITICAL": 0, "HIGH": 0,
-                   "MEDIUM": 0, "LOW": 0, "UNKNOWN": 0}
-        all_pkgs = {"CRITICAL": 0, "HIGH": 0,
-                    "MEDIUM": 0, "LOW": 0, "UNKNOWN": 0}
+        lang_pkgs = {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0, "UNKNOWN": 0}
+        os_pkgs = {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0, "UNKNOWN": 0}
+        all_pkgs = {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0, "UNKNOWN": 0}
 
         for vulnerability in flatten_vulnerabilities(report_json):
             clss = vulnerability["class"]
@@ -112,16 +123,21 @@ def main(report_path, print_header):
                 lang_pkgs[sev] += 1
 
         base_info = "%s,%s" % (oci_image, base_os)
-        all_pkgs_info = "%s,%s,%s,%s" % (all_pkgs['CRITICAL'],
-                                         all_pkgs['HIGH'],
-                                         all_pkgs['MEDIUM'], all_pkgs['LOW'])
-        crit_info = "%s,%s" % (os_pkgs['CRITICAL'], lang_pkgs['CRITICAL'])
-        high_info = "%s,%s" % (os_pkgs['HIGH'], lang_pkgs['HIGH'])
-        medium_info = "%s,%s" % (os_pkgs['MEDIUM'], lang_pkgs['MEDIUM'])
-        low_info = "%s,%s" % (os_pkgs['LOW'], lang_pkgs['LOW'])
+        all_pkgs_info = "%s,%s,%s,%s" % (
+            all_pkgs["CRITICAL"],
+            all_pkgs["HIGH"],
+            all_pkgs["MEDIUM"],
+            all_pkgs["LOW"],
+        )
+        crit_info = "%s,%s" % (os_pkgs["CRITICAL"], lang_pkgs["CRITICAL"])
+        high_info = "%s,%s" % (os_pkgs["HIGH"], lang_pkgs["HIGH"])
+        medium_info = "%s,%s" % (os_pkgs["MEDIUM"], lang_pkgs["MEDIUM"])
+        low_info = "%s,%s" % (os_pkgs["LOW"], lang_pkgs["LOW"])
 
-        print("%s,%s,%s,%s,%s,%s" % (base_info, all_pkgs_info, crit_info,
-                                     high_info, medium_info, low_info))
+        print(
+            "%s,%s,%s,%s,%s,%s"
+            % (base_info, all_pkgs_info, crit_info, high_info, medium_info, low_info)
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/images/get-summary.py
+++ b/scripts/images/get-summary.py
@@ -78,7 +78,10 @@ def main(report_path):
             if record["class"] == "lang-pkgs":
                 lang_pkgs[record["severity"]] = lang_pkgs[record["severity"]] + 1
 
-        print(f"{record['artifact']},{record['base']},{os_pkgs['CRITICAL']},{os_pkgs['HIGH']},{os_pkgs['MEDIUM']},{os_pkgs['LOW']},{lang_pkgs['CRITICAL']},{lang_pkgs['HIGH']},{lang_pkgs['MEDIUM']},{lang_pkgs['LOW']}")
+        print(
+            f"{record['artifact']},{record['base']},{os_pkgs['CRITICAL']},{os_pkgs['HIGH']},{os_pkgs['MEDIUM']},{os_pkgs['LOW']},{lang_pkgs['CRITICAL']},{lang_pkgs['HIGH']},{lang_pkgs['MEDIUM']},{lang_pkgs['LOW']}"
+        )  # noqa
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/scripts/images/get-summary.py
+++ b/scripts/images/get-summary.py
@@ -8,9 +8,10 @@
 import argparse
 import json
 from pathlib import Path
+from typing import List
 
 
-def get_reports_files_list(report_path: str) -> list[str]:
+def get_reports_files_list(report_path: str) -> List[str]:
     """
     Return the list of report files to be scanned.
 
@@ -53,7 +54,7 @@ def get_oci_image_name(report_json: dict) -> str:
     return report_json[OCI_IMAGE_KEY]
 
 
-def flatten_vulnerabilities(report_json) -> list[dict]:
+def flatten_vulnerabilities(report_json) -> List[dict]:
     """Return a list of vulnerabilites that contain severity and class."""
     if "Results" not in report_json:
         # no scan results found, skip this report

--- a/scripts/images/scan-images.sh
+++ b/scripts/images/scan-images.sh
@@ -46,6 +46,6 @@ for IMAGE in "${IMAGE_LIST[@]}"; do
     df . -h
 done
 
-./get-summary.py --report-path $TRIVY_REPORTS_DIR --print-header >> $SCAN_SUMMARY_FILE
+./get-summary.py --report-path $TRIVY_REPORTS_DIR --print-header > $SCAN_SUMMARY_FILE
 
 cat $SCAN_SUMMARY_FILE

--- a/scripts/images/scan-images.sh
+++ b/scripts/images/scan-images.sh
@@ -10,7 +10,6 @@
 FILE=$1
 TRIVY_REPORTS_DIR="trivy-reports"
 TRIVY_REPORT_TYPE="json"
-REPORT_TOTALS=false
 
 if [ -d "$TRIVY_REPORTS_DIR" ]; then
     echo "WARNING: $TRIVY_REPORTS_DIR directory already exists. Some reports might not be generated."
@@ -22,7 +21,7 @@ DATE=$(date +%F)
 SCAN_SUMMARY_FILE="scan-summary.csv"
 if [ ! -f $SCAN_SUMMARY_FILE ]; then
     # create header for scan summary file, if it does not exist
-    echo "IMAGE,BASE,CRITICAL,HIGH,MEDIUM,LOW " >> $SCAN_SUMMARY_FILE
+    echo "IMAGE,BASE,OS-CRITICAL,OS-HIGH,OS-MEDIUM,OS-LOW,LANG-CRITICAL,LANG-HIGH,LANG-MEDIUM,LANG-LOW" >> $SCAN_SUMMARY_FILE
 fi
 
 # create directory for trivy reports
@@ -48,23 +47,11 @@ for IMAGE in "${IMAGE_LIST[@]}"; do
     docker run -v /var/run/docker.sock:/var/run/docker.sock -v `pwd`:`pwd` -w `pwd` --name=scanner aquasec/trivy image --timeout 30m -f $TRIVY_REPORT_TYPE -o $TRIVY_REPORT --ignore-unfixed $IMAGE
     if [ "$TRIVY_REPORT_TYPE" = "json" ]; then
       # for JSON type retrieve severity counts
-      NUM_CRITICAL=$(grep CRITICAL $TRIVY_REPORT | wc -l)
-      NUM_HIGH=$(grep HIGH $TRIVY_REPORT | wc -l)
-      NUM_MEDIUM=$(grep MEDIUM $TRIVY_REPORT | wc -l)
-      NUM_LOW=$(grep LOW $TRIVY_REPORT | wc -l)
-      BASE=$(cat $TRIVY_REPORT | jq '.Metadata.OS | "\(.Family):\(.Name)"' | sed 's/"//g')
-      echo "$IMAGE,$BASE,$NUM_CRITICAL,$NUM_HIGH,$NUM_MEDIUM,$NUM_LOW" >> $SCAN_SUMMARY_FILE
+      get-summary.py --report-path $TRIVY_REPORT >> $SCAN_SUMMARY_FILE
     fi
     docker rmi $IMAGE
     docker rm -f $(docker ps -a -q)
     df . -h
 done
 
-if [ "$REPORT_TOTALS" = true ]; then
-    NUM_CRITICAL=$(grep CRITICAL "$TRIVY_REPORTS_DIR/*" | wc -l)
-    NUM_HIGH=$(grep HIGH "$TRIVY_REPORTS_DIR/*" | wc -l)
-    NUM_MEDIUM=$(grep MEDIUM "$TRIVY_REPORTS_DIR/*" | wc -l)
-    NUM_LOW=$(grep LOW "$TRIVY_REPORTS_DIR/*" | wc -l)
-    echo ",Totals:,$NUM_CRITICAL,$NUM_HIGH,$NUM_MEDIUM,$NUM_LOW" >> $SCAN_SUMMARY_FILE
-fi
 cat $SCAN_SUMMARY_FILE

--- a/scripts/images/scan-images.sh
+++ b/scripts/images/scan-images.sh
@@ -46,6 +46,6 @@ for IMAGE in "${IMAGE_LIST[@]}"; do
     df . -h
 done
 
-get-summary.py --report-path $TRIVY_REPORTS_DI --print-header >> $SCAN_SUMMARY_FILE
+./get-summary.py --report-path $TRIVY_REPORTS_DI --print-header >> $SCAN_SUMMARY_FILE
 
 cat $SCAN_SUMMARY_FILE

--- a/scripts/images/scan-images.sh
+++ b/scripts/images/scan-images.sh
@@ -21,7 +21,7 @@ DATE=$(date +%F)
 SCAN_SUMMARY_FILE="scan-summary.csv"
 if [ ! -f $SCAN_SUMMARY_FILE ]; then
     # create header for scan summary file, if it does not exist
-    echo "IMAGE,BASE,OS-CRITICAL,OS-HIGH,OS-MEDIUM,OS-LOW,LANG-CRITICAL,LANG-HIGH,LANG-MEDIUM,LANG-LOW" >> $SCAN_SUMMARY_FILE
+    echo "IMAGE,BASE,CRITICAL,HIGH,MEDIUM,LOW,CRITICAL-OS,CRITICAL-LANG,HIGH-OS,HIGH-LANG,MEDIUM-OS,MEDIUM-LANG,LOW-OS,LOW-LANG" >> $SCAN_SUMMARY_FILE
 fi
 
 # create directory for trivy reports

--- a/scripts/images/scan-images.sh
+++ b/scripts/images/scan-images.sh
@@ -46,6 +46,6 @@ for IMAGE in "${IMAGE_LIST[@]}"; do
     df . -h
 done
 
-./get-summary.py --report-path $TRIVY_REPORTS_DI --print-header >> $SCAN_SUMMARY_FILE
+./get-summary.py --report-path $TRIVY_REPORTS_DIR --print-header >> $SCAN_SUMMARY_FILE
 
 cat $SCAN_SUMMARY_FILE


### PR DESCRIPTION
CVE scanner script produces a report with counts of CVEs per severity. Trivy report provide Class of the target for which CVE was detected. There are two classes `os-pkgs` and `lang-pkgs`. This PR contains changes that generate CVE report per class.
This will allow more accurate analysis of CVEs.

Summary of changes:
- Added script that generates CVE count summary per class, i.e. for OS and LANG packages classes in Trivy reports.
- Modified main shell script to properly format report and call new script.
NOTE: When scanner cannot identify base image it is indicated as `N/A`. This is the case for ROCK images.

Testing new format:
```
IMAGE,BASE,CRITICAL,HIGH,MEDIUM,LOW,CRITICAL-OS,CRITICAL-LANG,HIGH-OS,HIGH-LANG,MEDIUM-OS,MEDIUM-LANG,LOW-OS,LOW-LANG
docker.io/charmedkubeflow/seldon-core-operator:v1.15.0_22.04_1,N/A,0,4,0,0,0,0,0,4,0,0,0,0
docker.io/kubeflownotebookswg/volumes-web-app:v1.7.0,debian:11.6,1,9,10,0,0,1,8,1,8,2,0,0
docker.io/kubeflownotebookswg/notebook-controller:v1.7.0,debian:11.6,0,58,21,0,0,0,4,54,4,17,0,0
kubeflownotebookswg/tensorboard-controller:v1.7.0,debian:11.6,0,6,1,0,0,0,0,6,0,1,0,0
docker.io/kubeflownotebookswg/kfam:v1.7.0,debian:11.6,0,15,8,0,0,0,4,11,4,4,0,0
kubeflownotebookswg/tensorboards-web-app:v1.7.0,debian:11.6,1,9,10,0,0,1,8,1,8,2,0,0
docker.io/kubeflownotebookswg/jupyter-web-app:v1.7.0,debian:11.6,1,9,10,0,0,1,8,1,8,2,0,0
docker.io/charmedkubeflow/mlserver-xgboost:1.2.0_22.04_1,ubuntu:22.04,3,8,5,4,0,3,0,8,0,5,0,4
docker.io/seldonio/engine:1.12.0,debian:10.2,36,95,95,6,21,15,56,39,50,45,4,2
docker.io/seldonio/seldon-core-executor:1.14.0,debian:10.12,6,17,16,2,6,0,14,3,16,0,2,0
docker.io/charmedkubeflow/mlserver-mlflow:1.2.0_22.04_1,ubuntu:22.04,4,9,6,4,0,4,0,9,0,6,0,4
docker.io/kubeflownotebookswg/centraldashboard:v1.7.0,alpine:3.15.4,6,29,20,2,1,5,10,19,10,10,0,2
docker.io/charmedkubeflow/mlserver-sklearn:1.2.0_22.04_1,ubuntu:22.04,3,8,5,4,0,3,0,8,0,5,0,4
docker.io/kubeflownotebookswg/profile-controller:v1.7.0,debian:11.6,1,56,21,0,0,1,4,52,4,17,0,0
```