### PR TITLE
fix: update scan images script

### DIFF
--- a/scripts/images/scan-images.sh
+++ b/scripts/images/scan-images.sh
@@ -17,8 +17,6 @@ if [ -d "$TRIVY_REPORTS_DIR" ]; then
 fi
 
 echo "Scan container images specified in $FILE"
-DATE=$(date +%F)
-SCAN_SUMMARY_FILE="scan-summary.csv"
 
 # create directory for trivy reports
 mkdir -p "$TRIVY_REPORTS_DIR"
@@ -45,7 +43,3 @@ for IMAGE in "${IMAGE_LIST[@]}"; do
     docker rm -f $(docker ps -a -q)
     df . -h
 done
-
-./get-summary.py --report-path $TRIVY_REPORTS_DIR --print-header > $SCAN_SUMMARY_FILE
-
-cat $SCAN_SUMMARY_FILE


### PR DESCRIPTION
Scan images script is used in GH workflow that reply on job's directory structure. This script needs to be updated to make it suitable  for use in workflows.

Issue and solution is described in https://github.com/canonical/bundle-kubeflow/issues/667

Summary of changes:
- Removed call to get-summary.py from scan-images.sh to enable independent use of scripts in workflows.
NOTE: Workflows might need to change to use scripts separately. Eg. https://github.com/canonical/bundle-kubeflow/pull/666