### PR TITLE
Update dump-charm-debug-artifacts to use `$HOME`

### DIFF
--- a/actions/dump-charm-debug-artifacts/action.yml
+++ b/actions/dump-charm-debug-artifacts/action.yml
@@ -26,8 +26,8 @@ runs:
       run: |
         wget https://github.com/corneliusweig/ketall/releases/download/v1.3.8/get-all-amd64-linux.tar.gz
         tar -xf get-all-amd64-linux.tar.gz
-        mkdir -p /home/runner/.local/bin/
-        mv get-all-amd64-linux /home/runner/.local/bin/ketall
+        mkdir -p $HOME/.local/bin/
+        mv get-all-amd64-linux $HOME/.local/bin/ketall
 
     # Dump logs
 


### PR DESCRIPTION
Use `$HOME` instead of hardcoded `/home/runner` in order to be compatible 
with self-hosted runners too. Details in the issue below.

Fixes https://github.com/canonical/kubeflow-ci/issues/115