### PR TITLE
feat: add ngc-integrator-operator to sync_charmstore_credentials.yaml

### DIFF
--- a/.github/workflows/sync_charmstore_credentials.yaml
+++ b/.github/workflows/sync_charmstore_credentials.yaml
@@ -37,6 +37,7 @@ jobs:
             ^canonical/mlflow-operator$
             ^canonical/mlmd-operator$
             ^canonical/metacontroller-operator$
+            ^canonical/ngc-integrator-operator$
             ^canonical/notebook-operators$
             ^canonical/oidc-gatekeeper-operator$
             ^canonical/pvcviewer-operator$


### PR DESCRIPTION
Adds the repo https://github.com/canonical/ngc-integrator-operator to `sync_charmstore_credentials.yaml`