### PR TITLE
ci: use microk8s strict and pin juju version

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -45,10 +45,6 @@ jobs:
         juju-channel: 3.1/stable
         charmcraft-channel: latest/candidate
         microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
-    # TODO: Remove once the actions-operator does this automatically
-    - name: Configure kubectl
-      run: |
-        sg microk8s -c "microk8s config > ~/.kube/config"
 
     - name: Add model
       run: |

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -41,7 +41,8 @@ jobs:
       uses: charmed-kubernetes/actions-operator@main
       with:
         provider: microk8s
-        channel: 1.24/stable
+        channel: 1.25-strict/stable
+        juju-channel: 3.1/stable
         charmcraft-channel: latest/candidate
         microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
     # TODO: Remove once the actions-operator does this automatically


### PR DESCRIPTION
To keep consistency with the CKF owned repositories, we must pin the juju version to 3.1/stable, and install microk8s in strict mode to allow bootstraping juju 3.x controllers. This commit also pins microk8s to v1.25.

Fixes [this issue](https://github.com/canonical/kubeflow-ci/actions/runs/7614294450/job/20736238273#step:3:223)