### PR TITLE
ci: add canonical/namespace-node-affinity-operator to sync workflow

### DIFF
--- a/.github/workflows/sync_charmstore_credentials.yaml
+++ b/.github/workflows/sync_charmstore_credentials.yaml
@@ -37,6 +37,7 @@ jobs:
             ^canonical/mlflow-operator$
             ^canonical/mlmd-operator$
             ^canonical/metacontroller-operator$
+            ^canonical/namespace-node-affinity-operator$
             ^canonical/notebook-operators$
             ^canonical/oidc-gatekeeper-operator$
             ^canonical/pvcviewer-operator$


### PR DESCRIPTION
The canonical/namespace-node-affinity-operator repository was missing from this list.