### PR TITLE
ci: use juju 3.4/stable instead of 3.5/stable

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -42,7 +42,7 @@ jobs:
       with:
         provider: microk8s
         channel: 1.29-strict/stable
-        juju-channel: 3.5/stable
+        juju-channel: 3.4/stable
         charmcraft-channel: latest/candidate
         microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
 


### PR DESCRIPTION
Part of canonical/bundle-kubeflow#944