### PR TITLE
Use "set -xe" for exiting on errors

### DIFF
--- a/scripts/images/get-all-images.sh
+++ b/scripts/images/get-all-images.sh
@@ -4,6 +4,8 @@
 # charm's repository one by one using specified branch and collects images referred by that charm
 # using that repository's image collection script
 #
+set -xe
+
 BUNDLE_FILE=$1
 IMAGES=()
 # retrieve all repositories and branches for CKF

--- a/scripts/images/get-images.sh
+++ b/scripts/images/get-images.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/bash
+
+set -xe
+
 BUNDLE_FILE=$1
 IMAGES=()
 REPOS=($(grep _github_repo_name $BUNDLE_FILE | awk '{print $2}' | sort --unique))

--- a/scripts/images/scan-images.sh
+++ b/scripts/images/scan-images.sh
@@ -6,6 +6,7 @@
 #
 # Usage: scan.sh <file>
 #
+set -xe
 
 FILE=$1
 TRIVY_REPORTS_DIR="trivy-reports"


### PR DESCRIPTION
Refs https://github.com/canonical/bundle-kubeflow/issues/1030

The current scanning action is failing because the bash script for gathering the image is failing, but the whole step is not failing
https://github.com/canonical/bundle-kubeflow/actions/runs/10482022617/job/29032456143#step:6:13
```
Error: open releases/1.9/stable/kubeflow/bundle.yaml: no such file or directory
Error: open releases/1.9/stable/kubeflow/bundle.yaml: no such file or directory
Image list:

```

This PR adds `set -xe` to all the bash scripts, to ensure they will exit if any of their sub-commands exits prematurely