### PR TITLE
fix: pass --db-repository option to scanner

### DIFF
--- a/scripts/images/scan-images.sh
+++ b/scripts/images/scan-images.sh
@@ -39,7 +39,9 @@ for IMAGE in "${IMAGE_LIST[@]}"; do
     fi
     echo "Scan image $IMAGE report in $TRIVY_REPORT"
     docker pull $IMAGE
-    docker run -v /var/run/docker.sock:/var/run/docker.sock -v `pwd`:`pwd` -w `pwd` --name=scanner aquasec/trivy image --timeout 30m -f $TRIVY_REPORT_TYPE -o $TRIVY_REPORT --ignore-unfixed $IMAGE
+    # Adding --db-repository public.ecr.aws/aquasecurity/trivy-db:2 option
+    # as a workaround for https://github.com/aquasecurity/trivy-action/issues/389
+    docker run -v /var/run/docker.sock:/var/run/docker.sock -v `pwd`:`pwd` -w `pwd` --name=scanner aquasec/trivy image --timeout 30m -f $TRIVY_REPORT_TYPE -o $TRIVY_REPORT --ignore-unfixed $IMAGE --db-repository public.ecr.aws/aquasecurity/trivy-db:2
     docker rmi $IMAGE
     docker rm -f $(docker ps -a -q)
     df . -h


### PR DESCRIPTION
This is a workaround for https://github.com/aquasecurity/trivy-action/issues/389

#### For reviewers

This change has been tested [here](https://github.com/canonical/bundle-kubeflow/actions/runs/11114666190) pointing to the branch of this PR. A way to test w/o the fix would be to run the "Scan images" workflow from `main` or observe the failure.

Fixes canonical/bundle-kubeflow#1080