### PR TITLE
fix: pass java-db-repository option to the scanner

### DIFF
--- a/scripts/images/scan-images.sh
+++ b/scripts/images/scan-images.sh
@@ -41,7 +41,7 @@ for IMAGE in "${IMAGE_LIST[@]}"; do
     docker pull $IMAGE
     # Adding --db-repository public.ecr.aws/aquasecurity/trivy-db:2 option
     # as a workaround for https://github.com/aquasecurity/trivy-action/issues/389
-    docker run -v /var/run/docker.sock:/var/run/docker.sock -v `pwd`:`pwd` -w `pwd` --name=scanner aquasec/trivy image --timeout 30m -f $TRIVY_REPORT_TYPE -o $TRIVY_REPORT --ignore-unfixed $IMAGE --db-repository public.ecr.aws/aquasecurity/trivy-db:2
+    docker run -v /var/run/docker.sock:/var/run/docker.sock -v `pwd`:`pwd` -w `pwd` --name=scanner aquasec/trivy image --timeout 30m -f $TRIVY_REPORT_TYPE -o $TRIVY_REPORT --ignore-unfixed $IMAGE --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --java-db-repository public.ecr.aws/aquasecurity/trivy-java-db:1
     docker rmi $IMAGE
     docker rm -f $(docker ps -a -q)
     df . -h


### PR DESCRIPTION
This is a workaround for aquasecurity/trivy-action#389

Fixes canonical/bundle-kubeflow#1080

#### For reviewers

This change has been tested [here](https://github.com/canonical/bundle-kubeflow/actions/runs/11226285214) pointing to the branch of this PR. A way to test w/o the fix would be to run the "Scan images" workflow from `main` or observe the failure.