### PR TITLE
ci: bump juju to 3.6 + charmcraft to 3.x/stable

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -42,8 +42,8 @@ jobs:
       with:
         provider: microk8s
         channel: 1.29-strict/stable
-        juju-channel: 3.4/stable
-        charmcraft-channel: latest/candidate
+        juju-channel: 3.6/stable
+        charmcraft-channel: 3.x/stable
         microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
 
     - name: Add model


### PR DESCRIPTION
* Bump juju to 3.6/stable
* For uniformity, use charmcraft from 3.x/stable

Ref canonical/bundle-kubeflow#1176