### PR TITLE
fix: Prefix artifact name with job name and run id

### DIFF
--- a/actions/dump-charm-debug-artifacts/README.md
+++ b/actions/dump-charm-debug-artifacts/README.md
@@ -27,7 +27,7 @@ To use this as a GitHub action, do:
 ```
 
 > [!IMPORTANT]
-> When calling the action multiple times for the same job (i.e. using a matrix), it's crucial to define `artifact-prefix`. Otherwise, the action will fail trying to upload logs from different jobs to the same file.
+> When calling the action from multiple runs of the same job (i.e. using a matrix), it's crucial to define `artifact-prefix`. Otherwise, the action will fail trying to upload logs from different job runs to the same file.
 
 To use this script directly, do:
 

--- a/actions/dump-charm-debug-artifacts/README.md
+++ b/actions/dump-charm-debug-artifacts/README.md
@@ -2,7 +2,7 @@
 
 Dumps logs relevant to kubernetes-based Juju charms to a GitHub Artifact.
 
-Logs are both printed to screen and dumped to the artifact "juju-kubernetes-charmcraft-logs".
+Logs are both printed to screen and dumped to the artifact `<prefix>-juju-kubernetes-charmcraft-logs`. Prefix has the form of `<job_name>-<artifact_prefix_input>`, where `-<artifact_prefix_input>` is present only when passed as an input to the job.
 
 Prerequisites for running this action in a workflow:
 * charmcraft
@@ -15,8 +15,6 @@ sensitive information is being shared.
 
 ## Example usage
 
-TODO: Complete the path below once this is placed in a longterm location.
-
 To use this as a GitHub action, do:
 
 ```yaml
@@ -24,7 +22,12 @@ To use this as a GitHub action, do:
   # always() if you want this to run on every run, regardless of failure. 
   # more details: https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions
   if: always()
+  with:
+    artifact-prefix: {{ matrix.charm }} # optional, see note below
 ```
+
+> [!IMPORTANT]
+> When calling the action multiple times for the same job (i.e. using a matrix), it's crucial to define `artifact-prefix`. Otherwise, the action will fail trying to upload logs from different jobs to the same file.
 
 To use this script directly, do:
 

--- a/actions/dump-charm-debug-artifacts/action.yml
+++ b/actions/dump-charm-debug-artifacts/action.yml
@@ -1,5 +1,9 @@
 name: 'Dump Charm Debug Artifacts'
 description: 'Dumps to Artifacts useful Juju, Kubernetes, and Charmcraft log information.  Requires kubectl to be set up with a context, and charmcraft to be installed.'
+inputs:
+  artifact-prefix:
+    description: "String used to prefix the uploaded artifact in order to ensure unique artifact names."
+    required: false
 runs:
   using: 'composite'
   steps:
@@ -45,10 +49,20 @@ runs:
         echo "folder_name=${PWD##*/}" >> "$GITHUB_ENV"
         echo "random_id=${RANDOM}" >> "$GITHUB_ENV"
 
+    - name: Export artifact prefix
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.artifact-prefix }}" ];
+        then
+          echo "prefix=${{ github.job }}-${{ inputs.artifact-prefix }}" >> "$GITHUB_ENV"
+        else
+          echo "prefix=${{ github.job }}" >> "$GITHUB_ENV"
+        fi
+
     - name: Upload debug artifacts
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: ${{ github.job }}-${{ env.folder_name }}-${{ env.random_id }}-juju-kubernetes-charmcraft-logs
+        name: ${{ env.prefix }}-juju-kubernetes-charmcraft-logs
         path: ${{ steps.mkdir.outputs.log-dir }}
         if-no-files-found: error

--- a/actions/dump-charm-debug-artifacts/action.yml
+++ b/actions/dump-charm-debug-artifacts/action.yml
@@ -39,10 +39,16 @@ runs:
 
     # Save logs
 
+    - name: Export artifact prefixes
+      shell: bash
+      run: |
+        echo "folder_name=${PWD##*/}" >> "$GITHUB_ENV"
+        echo "random_id=${RANDOM}" >> "$GITHUB_ENV"
+
     - name: Upload debug artifacts
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: ${{ github.job }}-${{github.run_id}}-juju-kubernetes-charmcraft-logs
+        name: ${{ github.job }}-${{ env.folder_name }}-${{ env.random_id }}-juju-kubernetes-charmcraft-logs
         path: ${{ steps.mkdir.outputs.log-dir }}
         if-no-files-found: error

--- a/actions/dump-charm-debug-artifacts/action.yml
+++ b/actions/dump-charm-debug-artifacts/action.yml
@@ -43,7 +43,7 @@ runs:
 
     # Save logs
 
-    - name: Export artifact prefix
+    - name: Set artifact prefix env
       shell: bash
       run: |
         if [ -n "${{ inputs.artifact-prefix }}" ];

--- a/actions/dump-charm-debug-artifacts/action.yml
+++ b/actions/dump-charm-debug-artifacts/action.yml
@@ -43,12 +43,6 @@ runs:
 
     # Save logs
 
-    - name: Export artifact prefixes
-      shell: bash
-      run: |
-        echo "folder_name=${PWD##*/}" >> "$GITHUB_ENV"
-        echo "random_id=${RANDOM}" >> "$GITHUB_ENV"
-
     - name: Export artifact prefix
       shell: bash
       run: |

--- a/actions/dump-charm-debug-artifacts/action.yml
+++ b/actions/dump-charm-debug-artifacts/action.yml
@@ -43,6 +43,6 @@ runs:
       uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: juju-kubernetes-charmcraft-logs
+        name: ${{ github.job }}-${{github.run_id}}-juju-kubernetes-charmcraft-logs
         path: ${{ steps.mkdir.outputs.log-dir }}
         if-no-files-found: error


### PR DESCRIPTION
Since v4 of the upload-artifact, artifacts are immutable. Thus, 
enable optional input `artifact-prefix` in order to avoid uploading logs
from different jobs to the same artifact. This input is neccesary when
the action is being called multiple times for the same job using a
matrix. On top of that, always prefix the artifact with the job name.

Fix #152

Tested in https://github.com/canonical/kfp-operators/pull/661, the created artifacts should be accessible here https://github.com/canonical/kfp-operators/actions/runs/12985907043.