### PR TITLE
CVE reports: Adds ability to set Jira token

### DIFF
--- a/scripts/cve-reports/send-scan.py
+++ b/scripts/cve-reports/send-scan.py
@@ -18,6 +18,8 @@ import requests
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, stream=sys.stdout, format="%(message)s")
 
+# https://support.atlassian.com/cloud-automation/docs/configure-the-incoming-webhook-trigger-in-atlassian-automation/
+HEADER_JIRA_TOKEN = "X-Automation-Webhook-Token"
 
 severity_to_priority_map = {
     "CRITICAL": "Highest",
@@ -135,6 +137,7 @@ def parse_sarif(filename: Path) -> List[Dict[str, str]]:
 def send_request_with_records(
     records: List[Dict[str, str]],
     jira_url: str,
+    jira_auth_token: str = "",
     gh_metadata: Dict[str, str] = {},
     verbose: bool = False,
 ) -> None:
@@ -143,25 +146,35 @@ def send_request_with_records(
     Args:
       records(List[Dict[str, str]]): a list of records of CVE's.
       jira_url(str): the url to send the request to.
+      jira_auth_token(str): the auth token to use when sending requests to Jira.
+        https://support.atlassian.com/cloud-automation/docs/configure-the-incoming-webhook-trigger-in-atlassian-automation/
       gh_metadata(Dict[str, str]): a dictionary containing the GitHub metadata
         to attach to the request, defaults to {}.
       verbose(bool): if True body of request and response code will be printed.
     """
 
+    headers = {}
+    if jira_auth_token:
+        headers[HEADER_JIRA_TOKEN] = jira_auth_token
+
     for record in records:
         record = {**record, **gh_metadata}
-        res = requests.post(jira_url, json=record)
+        res = requests.post(jira_url, headers=headers, json=record)
         if verbose:
             logger.info(record)
             logger.info(res)
 
 
-def main(report_path: str, jira_url: str, gh_meta: bool, verbose: bool) -> None:
+def main(
+    report_path: str, jira_url: str, jira_auth_token: str, gh_meta: bool, verbose: bool
+) -> None:
     """Main function for processing CVE's files.
 
     Args:
       report_path(str): path where report is stored
       jira_url(str): the url to send the request to.
+      jira_auth_token(str): the auth token to use when sending requests to Jira.
+        https://support.atlassian.com/cloud-automation/docs/configure-the-incoming-webhook-trigger-in-atlassian-automation/
       gh_meta(bool): if True GitHub metadata will be attached to the request.
       verbose(bool): if True GitHub metadata will be attached to the request.
     """
@@ -191,14 +204,15 @@ def main(report_path: str, jira_url: str, gh_meta: bool, verbose: bool) -> None:
         else:
             logger.warning(f"Unsupported file type: {file}. Skip it.")
             continue
-        send_request_with_records(records, jira_url, gh_metadata, verbose)
+        send_request_with_records(records, jira_url, jira_auth_token, gh_metadata, verbose)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--report-path")
     parser.add_argument("--jira-url")
+    parser.add_argument("--jira-auth-token", default="")
     parser.add_argument("--add-github-meta", action="store_true")
     parser.add_argument("--verbose", action="store_true")
     args = parser.parse_args()
-    main(args.report_path, args.jira_url, args.add_github_meta, args.verbose)
+    main(args.report_path, args.jira_url, args.jira_auth_token, args.add_github_meta, args.verbose)


### PR DESCRIPTION
According to the documentation [1], we can set the `X-Automation-Webhook-Token` HTTP header containing the Jira auth token, instead of having the token in the URL itself. Having it as a header is more secure.

[1] https://support.atlassian.com/cloud-automation/docs/configure-the-incoming-webhook-trigger-in-atlassian-automation/