### PR TITLE
chore: add feast-operators repo to sync charmcraft creds

### DIFF
--- a/.github/workflows/sync_charmstore_credentials.yaml
+++ b/.github/workflows/sync_charmstore_credentials.yaml
@@ -23,6 +23,7 @@ jobs:
             ^canonical/bundle-kubeflow$
             ^canonical/dex-auth-operator$
             ^canonical/envoy-operator$
+            ^canonical/feast-operators$
             ^canonical/github-profiles-automator$
             ^canonical/istio-operators$
             ^canonical/katib-operators$


### PR DESCRIPTION
Part of https://github.com/canonical/bundle-kubeflow/issues/1207