### PR TITLE
chore: add velero operator for charmcraft credentials

### DIFF
--- a/.github/workflows/sync_charmstore_credentials.yaml
+++ b/.github/workflows/sync_charmstore_credentials.yaml
@@ -46,6 +46,7 @@ jobs:
             ^canonical/pvcviewer-operator$
             ^canonical/resource-dispatcher$
             ^canonical/training-operator$
+            ^canonical/velero-operator$
           dry_run: ${{ github.event.inputs.DRY_RUN }}
           github_token: ${{ secrets.PAT_TOKEN }}
           concurrency: 10


### PR DESCRIPTION
Since Velero is now usable for taking backups, and is owned by Kubeflow Charmers
https://charmhub.io/velero-operator