### PR TITLE
feat: create workflow to sync `GH_TOKEN` to rock repos

### DIFF
--- a/.github/workflows/sync_charmstore_credentials.yaml
+++ b/.github/workflows/sync_charmstore_credentials.yaml
@@ -48,7 +48,7 @@ jobs:
             ^canonical/training-operator$
             ^canonical/velero-operator$
           dry_run: ${{ github.event.inputs.DRY_RUN }}
-          github_token: ${{ secrets.PAT_TOKEN }}
+          github_token: ${{ secrets.GH_TOKEN }}
           concurrency: 10
         env:
           CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS }}

--- a/.github/workflows/sync_github_token.yaml
+++ b/.github/workflows/sync_github_token.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: jpoehnelt/secrets-sync-action@7840777f242539d96b60477b66aa1c179e7644ea
         with:
           secrets: |
-            ^PAT_TOKEN$
+            ^GH_TOKEN$
           repositories: |
             ^canonical/katib-rocks
             ^canonical/pipelines-rocks
@@ -34,7 +34,7 @@ jobs:
             ^canonical/training-operator-rock
             ^canonical/dex-auth-rocks
           dry_run: ${{ github.event.inputs.DRY_RUN }}
-          github_token: ${{ secrets.PAT_TOKEN }}
+          github_token: ${{ secrets.GH_TOKEN }}
           concurrency: 10
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/sync_github_token.yaml
+++ b/.github/workflows/sync_github_token.yaml
@@ -23,7 +23,6 @@ jobs:
             ^canonical/resource-dispatcher-rock
             ^canonical/feast-rocks
             ^canonical/kubeflow-rocks
-            ^canonical/seldonio-rocks
             ^canonical/knative-rocks
             ^canonical/metacontroller-rock
             ^canonical/filebrowser-rock

--- a/.github/workflows/sync_github_token.yaml
+++ b/.github/workflows/sync_github_token.yaml
@@ -10,7 +10,7 @@ on:
         default: 'true'
 
 jobs:
-  sync_charmstore_credentials:
+  sync_github_token:
     runs-on: ubuntu-24.04
     steps:
       - uses: jpoehnelt/secrets-sync-action@7840777f242539d96b60477b66aa1c179e7644ea

--- a/.github/workflows/sync_github_token.yaml
+++ b/.github/workflows/sync_github_token.yaml
@@ -1,7 +1,6 @@
 name: Sync Github token to rock repos
 
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       DRY_RUN:

--- a/.github/workflows/sync_github_token.yaml
+++ b/.github/workflows/sync_github_token.yaml
@@ -32,6 +32,7 @@ jobs:
             ^canonical/tensorflow-rock
             ^canonical/training-operator-rock
             ^canonical/dex-auth-rocks
+            ^canonical/base-mlflow
           dry_run: ${{ github.event.inputs.DRY_RUN }}
           github_token: ${{ secrets.GH_TOKEN }}
           concurrency: 10

--- a/.github/workflows/sync_github_token.yaml
+++ b/.github/workflows/sync_github_token.yaml
@@ -1,0 +1,40 @@
+name: Sync Github token to rock repos
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      DRY_RUN:
+        description: 'true/false whether to run action in dry-run mode'
+        required: true
+        default: 'true'
+
+jobs:
+  sync_charmstore_credentials:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: jpoehnelt/secrets-sync-action@7840777f242539d96b60477b66aa1c179e7644ea
+        with:
+          secrets: |
+            ^GH_TOKEN$
+          repositories: |
+            ^canonical/katib-rocks
+            ^canonical/pipelines-rocks
+            ^canonical/kserve-rocks
+            ^canonical/resource-dispatcher-rock
+            ^canonical/feast-rocks
+            ^canonical/kubeflow-rocks
+            ^canonical/seldonio-rocks
+            ^canonical/knative-rocks
+            ^canonical/metacontroller-rock
+            ^canonical/filebrowser-rock
+            ^canonical/argo-workflows-rocks
+            ^canonical/oidc-authservice-rock
+            ^canonical/tensorflow-rock
+            ^canonical/training-operator-rock
+            ^canonical/dex-auth-rocks
+          dry_run: ${{ github.event.inputs.DRY_RUN }}
+          github_token: ${{ secrets.PAT_TOKEN }}
+          concurrency: 10
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/sync_github_token.yaml
+++ b/.github/workflows/sync_github_token.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: jpoehnelt/secrets-sync-action@7840777f242539d96b60477b66aa1c179e7644ea
         with:
           secrets: |
-            ^GH_TOKEN$
+            ^PAT_TOKEN$
           repositories: |
             ^canonical/katib-rocks
             ^canonical/pipelines-rocks


### PR DESCRIPTION
Closes #147 

Renames `PAT_TOKEN` secret to `GH_TOKEN` for consistency across repos.

Note to reviewer: temporarily set to run on pull request so a dry run is triggered in the CI as a test, see [this run](https://github.com/canonical/kubeflow-ci/actions/runs/17094360965/job/48475200241?pr=172). Will remove before merging.