### PR TITLE
fix: Properly pass secrets in `sync_gpg_secrets.yaml`

### DIFF
--- a/.github/workflows/sync_gpg_secrets.yaml
+++ b/.github/workflows/sync_gpg_secrets.yaml
@@ -45,4 +45,5 @@ jobs:
           github_token: ${{ secrets.GH_TOKEN }}
           concurrency: 10
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}


### PR DESCRIPTION
This PR fixes `sync_gpg_secrets.yaml` to properly pass the environment variables needed for the action to run.

An example of a *failed* action is https://github.com/canonical/kubeflow-ci/actions/runs/23497054089 (the action succeeds but no secret is found).