### PR TITLE
feat: add velero-integrator-operator to charmstore credentials action

### DIFF
--- a/.github/workflows/sync_charmstore_credentials.yaml
+++ b/.github/workflows/sync_charmstore_credentials.yaml
@@ -47,6 +47,7 @@ jobs:
             ^canonical/resource-dispatcher$
             ^canonical/training-operator$
             ^canonical/velero-operator$
+            ^canonical/velero-integrator-operator$
           dry_run: ${{ github.event.inputs.DRY_RUN }}
           github_token: ${{ secrets.GH_TOKEN }}
           concurrency: 10


### PR DESCRIPTION
This PR adds the [velero-integrator-operator](velero-integratorvelero-integrator) repository to the list in Charmstore credentials update actions.