### PR TITLE
chore: bump actions version

### DIFF
--- a/.github/workflows/branch_automation.yaml
+++ b/.github/workflows/branch_automation.yaml
@@ -16,8 +16,9 @@ jobs:
     env:
       KUBEFLOW_BOT_TOKEN: ${{ secrets.KUBEFLOW_BOT_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
+          persist-credentials: false
           repository: canonical/bundle-kubeflow
           fetch-depth: 0
       - name: Set up Python 3.8

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -8,7 +8,9 @@ jobs:
     name: Lint Code
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up Python 3.8
         uses: actions/setup-python@v5.3.0
         with:
@@ -20,7 +22,9 @@ jobs:
     name: Branch Creation Script Tests
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up Python 3.8
         uses: actions/setup-python@v5.3.0
         with:
@@ -32,7 +36,9 @@ jobs:
     name: Batch Release Charms Script Tests
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up Python 3.8
         uses: actions/setup-python@v5.3.0
         with:
@@ -47,7 +53,9 @@ jobs:
     steps:
     # Set things up like a charm would.  Get juju and microk8s
     - name: Check out repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
+      with:
+          persist-credentials: false
 
     - name: Setup operator environment
       uses: charmed-kubernetes/actions-operator@main

--- a/actions/contributing-update/action.yaml
+++ b/actions/contributing-update/action.yaml
@@ -17,7 +17,9 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: 'actions/checkout@v3'
+    - uses: 'actions/checkout@v6'
+      with:
+        persist-credentials: false
     - name: 'Make temporary dir for this job'
       shell: bash
       run: |

--- a/actions/dump-charm-debug-artifacts/action.yml
+++ b/actions/dump-charm-debug-artifacts/action.yml
@@ -8,7 +8,9 @@ runs:
   using: 'composite'
   steps:
     - name: Check out repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     # Setup
 
@@ -54,7 +56,7 @@ runs:
         fi
 
     - name: Upload debug artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: ${{ env.prefix }}-juju-kubernetes-charmcraft-logs

--- a/actions/get-charm-paths/README.md
+++ b/actions/get-charm-paths/README.md
@@ -19,8 +19,9 @@ jobs:
     outputs:
       charm_paths: ${{ steps.get-charm-paths.outputs.charm-paths }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Get paths for all charms in this repo
         id: get-charm-paths

--- a/actions/get-charm-paths/action.yml
+++ b/actions/get-charm-paths/action.yml
@@ -19,8 +19,11 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: 'actions/checkout@v3'
-    - name: 'Get paths for all charms in repo'
+    - uses: 'actions/checkout@v6'
+      with:
+        persist-credentials: false
+
+    - name: Get paths for all charms in repo
       id: get-charm-paths
       shell: bash
       run: python ${{ github.action_path }}/src/get_charm_paths.py ${{ inputs.base-dir }} --charms-subdir=${{ inputs.charms-subdir }}

--- a/cannon_runs/2021-12-06_publish_workflow_bundles/publish.yaml
+++ b/cannon_runs/2021-12-06_publish_workflow_bundles/publish.yaml
@@ -19,7 +19,9 @@ jobs:
     outputs:
       charm_paths_json: ${{ steps.get-charm-matrix-step.outputs.CHARM_PATHS_JSON }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Get paths for all charms in repo
         id: get-charm-matrix-step
         run: ./.github/workflows/get-charm-paths.sh
@@ -34,7 +36,9 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.get-charm-matrix.outputs.charm_paths_json) }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: canonical/charmhub-upload-action@0.2.0
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
@@ -48,7 +52,9 @@ jobs:
     env:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install dependencies
         run: sudo snap install charmcraft --classic --channel=latest/edge
       - name: Publish bundle using charmcraft

--- a/cannon_runs/2021-12-06_publish_workflow_charms/publish.yaml
+++ b/cannon_runs/2021-12-06_publish_workflow_charms/publish.yaml
@@ -19,7 +19,9 @@ jobs:
     # Only publish to charmhub if we are pushing to a special branch or running PRs from something named `branch/*`
     if: (github.event_name == 'push') ||  (startsWith( github.head_ref, 'branch/' ))
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       # TODO: Update to @main when https://github.com/canonical/charmhub-upload-action/pull/3 merged
       - uses: canonical/charmhub-upload-action@branch/upload-charm-revisions
         with:


### PR DESCRIPTION
This PR bumps version of `actions/checkout` and `actions/upload-artifact` to use Node 24.

Ref: #176 