### PR TITLE
chore: speed up debug artifacts action

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @canonical/kubeflow
+*       @canonical/mlops

--- a/actions/dump-charm-debug-artifacts/action.yml
+++ b/actions/dump-charm-debug-artifacts/action.yml
@@ -41,7 +41,7 @@ runs:
       run: |
         if [ -n "${{ inputs.artifact-prefix }}" ];
         then
-          echo "prefix=${{ github.job }}-${{ inputs.artifact-prefix }}" >> "$GITHUB_ENV"
+          echo "prefix=${{ inputs.artifact-prefix }}" >> "$GITHUB_ENV"
         else
           echo "prefix=${{ github.job }}" >> "$GITHUB_ENV"
         fi

--- a/actions/dump-charm-debug-artifacts/action.yml
+++ b/actions/dump-charm-debug-artifacts/action.yml
@@ -26,15 +26,6 @@ runs:
       shell: bash
       run: sudo snap install juju-crashdump --classic
 
-    - name: 'Install ketall'
-      # https://github.com/corneliusweig/ketall
-      shell: bash
-      run: |
-        wget https://github.com/corneliusweig/ketall/releases/download/v1.3.8/get-all-amd64-linux.tar.gz
-        tar -xf get-all-amd64-linux.tar.gz
-        mkdir -p $HOME/.local/bin/
-        mv get-all-amd64-linux $HOME/.local/bin/ketall
-
     # Dump logs
 
     - name: Collect all logs

--- a/actions/dump-charm-debug-artifacts/logdump.bash
+++ b/actions/dump-charm-debug-artifacts/logdump.bash
@@ -26,12 +26,6 @@ then
 	exit 1
 fi
 
-if ! command -v ketall &> /dev/null
-then
-	echo "error: required dependency ketall not found."
-	exit 1
-fi
-
 if ! snap list | grep juju-crashdump > /dev/null
 then
 	echo "error: required dependency juju-crashdump not found."
@@ -79,22 +73,17 @@ for model in `juju list-models --format yaml | yq e '.models[].name'`; do
 	for application in `juju status -m $model --format yaml | yq e '.applications | keys | .[]'`; do
 		echo juju show-status-log --days 1 --type application $application | tee "$OUTPUT_DIR/juju-status-logs-application-$application.txt"
 		juju show-status-log --days 1 --type application $application | tee "$OUTPUT_DIR/juju-status-logs-application-$application.txt"
+		pod=$(kubectl get pod -n kubeflow -l app.kubernetes.io/name=$application -o jsonpath='{.items[0].metadata.name}') || continue
+		containers=($(kubectl get pod -n $model $pod -o jsonpath='{.spec.containers[*].name}'))
+		for container in ${containers[@]}; do
+			kubectl logs -n $model $pod -c $container | tee "$OUTPUT_DIR/kubectl-logs-$application-$container.txt"
+		done
 	done
 	for unit in `juju status -m $model --format yaml | yq e '.applications[].units | keys | .[]'`; do
         echo juju show-status-log --days 1 --type unit $unit | tee "$OUTPUT_DIR/juju-status-logs-unit-${unit//\//-}.txt"
         juju show-status-log --days 1 --type unit $unit | tee "$OUTPUT_DIR/juju-status-logs-unit-${unit//\//-}.txt"
 	done
 done	
-
-
-############
-# Kubernetes
-
-kubectl cluster-info dump | tee "$OUTPUT_DIR/kubectl-cluster-info-dump.txt"
-
-# Deeper resource details and logs
-ketall | tee "$OUTPUT_DIR/kubernetes-ketall.txt"
-ketall -o yaml | tee "$OUTPUT_DIR/kubernetes-ketall-detailed.yaml"
 
 # exit with an error code if we hit any errors
 exit "$result"

--- a/actions/dump-charm-debug-artifacts/logdump.bash
+++ b/actions/dump-charm-debug-artifacts/logdump.bash
@@ -49,11 +49,11 @@ echo "Dumping logs to ${OUTPUT_DIR}"
 shopt -s nullglob
 # Common for most installs
 for f in $HOME/snap/charmcraft/common/cache/charmcraft/log/charmcraft-*.log; do
-    cat $f | tee "$OUTPUT_DIR/`basename $f`"
+    cat $f > "$OUTPUT_DIR/$(basename $f)"
 done
 # A spot sometimes seen on a gh runner
 for f in $HOME/.local/state/charmcraft/log/charmcraft-*.log; do
-    cat $f | tee "$OUTPUT_DIR/`basename $f`"
+    cat $f > "$OUTPUT_DIR/$(basename $f)"
 done
 shopt -u nullglob
 
@@ -66,22 +66,23 @@ juju-crashdump -o "$OUTPUT_DIR"
 
 # Collect `juju show-status-log` for every model, unit, and application
 # Expand $model and $unit with a substitution that replaces '/' with '-'
-for model in `juju list-models --format yaml | yq e '.models[].name'`; do
-    echo juju show-status-log --days 1 --type model $model | tee "$OUTPUT_DIR/juju-status-logs-model-${model//\//-}.txt"
-    juju show-status-log --days 1 --type model $model | tee "$OUTPUT_DIR/juju-status-logs-model-${model//\//-}.txt"
-
-	for application in `juju status -m $model --format yaml | yq e '.applications | keys | .[]'`; do
-		echo juju show-status-log --days 1 --type application $application | tee "$OUTPUT_DIR/juju-status-logs-application-$application.txt"
-		juju show-status-log --days 1 --type application $application | tee "$OUTPUT_DIR/juju-status-logs-application-$application.txt"
-		pod=$(kubectl get pod -n kubeflow -l app.kubernetes.io/name=$application -o jsonpath='{.items[0].metadata.name}') || continue
-		containers=($(kubectl get pod -n $model $pod -o jsonpath='{.spec.containers[*].name}'))
+for model in $(juju list-models --format yaml | yq e '.models[].short-name'); do
+    juju show-status-log --model $model --days 1 --type model $model > "$OUTPUT_DIR/juju-status-logs-model-$model.txt"
+	for application in $(juju status --model=$model --format yaml | yq e '.applications | keys | .[]'); do
+		juju show-status-log --model $model --days 1 --type application $application > "$OUTPUT_DIR/juju-status-logs-application-$application.txt"
+		k8s_model=$model
+		if [ $model == controller ]; then
+		    controller_name=$(juju status --model=$model --format yaml | yq e '.model.controller' )
+		    k8s_model=$model-$controller_name
+		fi
+		pod=$(kubectl get pod -n $k8s_model -l app.kubernetes.io/name=$application -o jsonpath='{.items[0].metadata.name}') || continue
+		containers=($(kubectl get pod -n $k8s_model $pod -o jsonpath='{.spec.containers[*].name}'))
 		for container in ${containers[@]}; do
-			kubectl logs -n $model $pod -c $container | tee "$OUTPUT_DIR/kubectl-logs-$application-$container.txt"
+			kubectl logs -n $k8s_model $pod -c $container > "$OUTPUT_DIR/kubectl-logs-$application-$container.txt"
 		done
 	done
-	for unit in `juju status -m $model --format yaml | yq e '.applications[].units | keys | .[]'`; do
-        echo juju show-status-log --days 1 --type unit $unit | tee "$OUTPUT_DIR/juju-status-logs-unit-${unit//\//-}.txt"
-        juju show-status-log --days 1 --type unit $unit | tee "$OUTPUT_DIR/juju-status-logs-unit-${unit//\//-}.txt"
+	for unit in $(juju status --model=$model --format yaml | yq e '.applications[].units | keys | .[]'); do
+        juju show-status-log --model=$model --days 1 --type unit $unit > "$OUTPUT_DIR/juju-status-logs-unit-${unit//\//-}.txt"
 	done
 done	
 

--- a/actions/dump-charm-debug-artifacts/logdump.bash
+++ b/actions/dump-charm-debug-artifacts/logdump.bash
@@ -62,11 +62,11 @@ shopt -u nullglob
 # Juju
 
 # Collect juju-crashdump
-juju-crashdump -o "$OUTPUT_DIR"
 
 # Collect `juju show-status-log` for every model, unit, and application
 # Expand $model and $unit with a substitution that replaces '/' with '-'
 for model in $(juju list-models --format yaml | yq e '.models[].short-name'); do
+	juju-crashdump --model $model -o "$OUTPUT_DIR"
     juju show-status-log --model $model --days 1 --type model $model > "$OUTPUT_DIR/juju-status-logs-model-$model.txt"
 	for application in $(juju status --model=$model --format yaml | yq e '.applications | keys | .[]'); do
 		juju show-status-log --model $model --days 1 --type application $application > "$OUTPUT_DIR/juju-status-logs-application-$application.txt"


### PR DESCRIPTION
This PR speeds up the Dump charm debug artifacts by skipping the `ketall` and `kubectl cluster-info dump` commands.
This PR also saves logs from all the containers of juju applications.
This PR also fixes the CODEOWNERS file.

This PR has been tested in [this CI run](https://github.com/canonical/kfp-operators/actions/runs/26221959030).

This PR closes #174.