### PR TITLE
fix(dump-debug-artifacts): always set artifact prefix env variable

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -57,14 +57,12 @@ jobs:
       with:
           persist-credentials: false
 
-    - name: Setup operator environment
-      uses: charmed-kubernetes/actions-operator@main
-      with:
-        provider: microk8s
-        channel: 1.32-strict/stable
-        juju-channel: 3.6/stable
-        charmcraft-channel: 3.x/stable
-        microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
+    - name: Setup environment
+      run: |
+        sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
+        sudo rm -rf /run/containerd
+        sudo snap install concierge --classic
+        sudo concierge prepare --trace
 
     - name: Add model
       run: |

--- a/actions/dump-charm-debug-artifacts/action.yml
+++ b/actions/dump-charm-debug-artifacts/action.yml
@@ -54,4 +54,3 @@ runs:
       with:
         name: ${{ env.prefix }}-juju-kubernetes-charmcraft-logs
         path: ${{ steps.mkdir.outputs.log-dir }}
-        if-no-files-found: error

--- a/actions/dump-charm-debug-artifacts/action.yml
+++ b/actions/dump-charm-debug-artifacts/action.yml
@@ -7,6 +7,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
+
     - name: Check out repo
       uses: actions/checkout@v6
       with:
@@ -37,6 +38,7 @@ runs:
     # Save logs
 
     - name: Set artifact prefix env
+      if: always()
       shell: bash
       run: |
         if [ -n "${{ inputs.artifact-prefix }}" ];

--- a/actions/dump-charm-debug-artifacts/action.yml
+++ b/actions/dump-charm-debug-artifacts/action.yml
@@ -7,7 +7,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-
     - name: Check out repo
       uses: actions/checkout@v6
       with:

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -1,0 +1,26 @@
+juju:
+  channel: 3.6/stable
+
+providers:
+  k8s:
+    enable: true
+    bootstrap: true
+    channel: 1.32-classic/stable
+    features:
+      local-storage:
+      load-balancer:
+        enabled: true
+        l2-mode: true
+        cidrs: 10.64.140.43/32
+    bootstrap-constraints:
+      root-disk: 2G
+
+  lxd:
+    enable: true
+    bootstrap: false
+    channel: latest/stable
+
+host:
+  snaps:
+    charmcraft:
+      channel: 3.x/stable


### PR DESCRIPTION
This PR fixes an issue for which the `actions/upload-artifact` step may be called without having the artifacts prefix properly set, resulting in the following call:
```
Run actions/upload-artifact@v7
  with:
    name: -juju-kubernetes-charmcraft-logs
    path: tmp_logs_integration
    if-no-files-found: error
```

The PR also avoids the action to fail when no files are found to upload, just warns.

This PR also migrates the pull request env setup to use `concierge`.