### PR TITLE
chore: add missing training and trainer rocks repos

### DIFF
--- a/.github/workflows/sync_github_token.yaml
+++ b/.github/workflows/sync_github_token.yaml
@@ -46,6 +46,7 @@ jobs:
             ^canonical/kubeflow-roles-operator$
             ^canonical/kubeflow-tensorboards-operator$
             ^canonical/kubeflow-trainer-operator$
+            ^canonical/kubeflow-trainer-rocks$
             ^canonical/kubeflow-volumes-operator$
             ^canonical/metacontroller-operator$
             ^canonical/minio-operator$
@@ -57,6 +58,7 @@ jobs:
             ^canonical/request-authentication-integrator$
             ^canonical/resource-dispatcher$
             ^canonical/training-operator$
+            ^canonical/training-operator-rocks$
           dry_run: ${{ github.event.inputs.DRY_RUN }}
           github_token: ${{ secrets.GH_TOKEN }}
           concurrency: 10

--- a/.github/workflows/sync_github_token.yaml
+++ b/.github/workflows/sync_github_token.yaml
@@ -50,6 +50,7 @@ jobs:
             ^canonical/kubeflow-volumes-operator$
             ^canonical/metacontroller-operator$
             ^canonical/minio-operator$
+            ^canonical/minio-rock$
             ^canonical/mlflow-operator$
             ^canonical/mlmd-operator$
             ^canonical/notebook-operators$

--- a/.github/workflows/sync_gpg_secrets.yaml
+++ b/.github/workflows/sync_gpg_secrets.yaml
@@ -32,6 +32,7 @@ jobs:
             ^canonical/kubeflow-roles-operator$
             ^canonical/kubeflow-tensorboards-operator$
             ^canonical/kubeflow-trainer-operator$
+            ^canonical/kubeflow-trainer-rocks$
             ^canonical/kubeflow-volumes-operator$
             ^canonical/metacontroller-operator$
             ^canonical/minio-operator$

--- a/.github/workflows/sync_gpg_secrets.yaml
+++ b/.github/workflows/sync_gpg_secrets.yaml
@@ -32,7 +32,6 @@ jobs:
             ^canonical/kubeflow-roles-operator$
             ^canonical/kubeflow-tensorboards-operator$
             ^canonical/kubeflow-trainer-operator$
-            ^canonical/kubeflow-trainer-rocks$
             ^canonical/kubeflow-volumes-operator$
             ^canonical/metacontroller-operator$
             ^canonical/minio-operator$


### PR DESCRIPTION
This PR adds the rocks repo for Minio, Training V1 and Trainer V2 for syncing GH token and GPG key.

This PR closes #189.