### PR TITLE
chore: rename `request-authentication-integrator` to `-configurator` in workflows

### DIFF
--- a/.github/workflows/sync_charmstore_credentials.yaml
+++ b/.github/workflows/sync_charmstore_credentials.yaml
@@ -45,7 +45,7 @@ jobs:
             ^canonical/notebook-operators$
             ^canonical/oidc-gatekeeper-operator$
             ^canonical/pvcviewer-operator$
-            ^canonical/request-authentication-integrator$
+            ^canonical/request-authentication-configurator$
             ^canonical/resource-dispatcher$
             ^canonical/training-operator$
             ^canonical/velero-operator$

--- a/.github/workflows/sync_github_token.yaml
+++ b/.github/workflows/sync_github_token.yaml
@@ -54,7 +54,7 @@ jobs:
             ^canonical/notebook-operators$
             ^canonical/oidc-gatekeeper-operator$
             ^canonical/pvcviewer-operator$
-            ^canonical/request-authentication-integrator$
+            ^canonical/request-authentication-configurator$
             ^canonical/resource-dispatcher$
             ^canonical/training-operator$
           dry_run: ${{ github.event.inputs.DRY_RUN }}

--- a/.github/workflows/sync_gpg_secrets.yaml
+++ b/.github/workflows/sync_gpg_secrets.yaml
@@ -40,7 +40,7 @@ jobs:
             ^canonical/notebook-operators$
             ^canonical/oidc-gatekeeper-operator$
             ^canonical/pvcviewer-operator$
-            ^canonical/request-authentication-integrator$
+            ^canonical/request-authentication-configurator$
             ^canonical/resource-dispatcher$
             ^canonical/training-operator$
           dry_run: ${{ github.event.inputs.DRY_RUN }}


### PR DESCRIPTION
Following https://github.com/canonical/canonical-repo-automation/pull/858